### PR TITLE
Optimize Sanity SEO and rendering performance

### DIFF
--- a/app/(web)/[slug]/page.tsx
+++ b/app/(web)/[slug]/page.tsx
@@ -1,10 +1,12 @@
 import PageTemplate from '@/components/pages/PageTemplate';
 import { ComponentsProps } from '@/components/types';
-import { GetPageDetailQueryResult, SettingsQueryResult } from '@/sanity.types';
-import { getSettingsFetch } from '@/sanity/lib/fetch';
+import { GetPageDetailQueryResult } from '@/sanity.types';
 import { getPageBySlugFetch } from '@/sanity/lib/fetchs/page.fetch';
 import type { Metadata } from 'next';
-import { Service, WithContext } from 'schema-dts';
+import { WebPage, WithContext } from 'schema-dts';
+import { buildDocumentMetadata, serializeJsonLd } from '@/sanity/lib/seo';
+import type { SeoDocument } from '@/sanity/lib/seo';
+import { notFound } from 'next/navigation';
 
 export async function generateMetadata({
   params,
@@ -12,16 +14,18 @@ export async function generateMetadata({
   params: { slug: string };
 }): Promise<Metadata> {
   const currentPage = await getData(params.slug);
-  return {
-    title: currentPage?.page?.title,
-  };
+  if (!currentPage) notFound();
+
+  return buildDocumentMetadata({
+    document: currentPage,
+    path: `/${params.slug}`,
+    fallbackImage: currentPage?.components?.[0]?.imageBackground,
+  });
 }
 
 async function getData(slug: string) {
   try {
-    const [page, settings]: [GetPageDetailQueryResult, SettingsQueryResult] =
-      await Promise.all([getPageBySlugFetch(slug), getSettingsFetch()]);
-    return { page, settings };
+    return (await getPageBySlugFetch(slug)) as GetPageDetailQueryResult;
   } catch (error) {
     console.error('Error fetching data:', error);
     return null;
@@ -30,48 +34,23 @@ async function getData(slug: string) {
 
 export default async function Page({ params }: { params: { slug: string } }) {
   const data = await getData(params?.slug);
-  if (!data) {
-    return <div>Página no encontrada.</div>;
-  }
-  const { page } = data;
+  if (!data) notFound();
+  const page = data;
+  const seoPage = page as unknown as SeoDocument;
 
-  const jsonLd: WithContext<Service> = {
+  const jsonLd: WithContext<WebPage> = {
     '@context': 'https://schema.org',
-    '@type': 'Service',
+    '@type': 'WebPage',
     name: page?.title || 'Abogados San Felipe',
-    description: 'Derecho Familiar e Inmobiliario',
-    serviceType: 'Asesoría Legal y Jurídica',
-    provider: {
-      '@type': 'Organization',
-      name: 'Abogados San Felipe - Sebastián Bonilla Marín',
-      address: {
-        '@type': 'PostalAddress',
-        addressLocality: 'San Felipe',
-        addressRegion: 'Valparaíso',
-        postalCode: '2170000',
-        addressCountry: 'CL',
-      },
-      telephone: '+56 9 3359 6955',
-      email: 'contacto@abogadossanfelipe.cl',
-      url: 'https://www.abogadossanfelipe.cl',
-    },
-    areaServed: 'San Felipe, Chile',
-    offers: {
-      '@type': 'Offer',
-      price: 'Consultar',
-      priceCurrency: 'CLP',
-    },
+    description: seoPage.seo?.metaDescription || page?.resumen || undefined,
+    url: `https://www.abogadossanfelipe.cl/${params.slug}`,
   };
-
-  if (!page) {
-    return <div>Pagina no encontrado.</div>; // Manejo básico de errores
-  }
 
   return (
     <section>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
       />
       {page?.components ? (
         <PageTemplate components={page.components as ComponentsProps} />

--- a/app/(web)/area-de-practica/[slug]/page.tsx
+++ b/app/(web)/area-de-practica/[slug]/page.tsx
@@ -11,8 +11,9 @@ import {
 } from '@/sanity.types';
 import { getPostListByUnitBusinessFetch } from '@/sanity/lib/fetchs/post.fetch';
 import { getUnitBusinessBySlugFetch } from '@/sanity/lib/fetchs/unitBusiness.fetch';
-import { resolveOpenGraphImage, urlForImage } from '@/sanity/lib/utils';
+import { buildDocumentMetadata } from '@/sanity/lib/seo';
 import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 
 export async function generateMetadata({
   params,
@@ -20,18 +21,14 @@ export async function generateMetadata({
   params: { slug: string };
 }): Promise<Metadata> {
   const data = await getData(params.slug);
-  if (!data) return { title: 'Servicio no encontrado' };
+  if (!data?.unitBusiness) notFound();
+
   const { unitBusiness } = data;
-  return {
-    title: unitBusiness?.title,
-    openGraph: {
-      title: unitBusiness?.title || '',
-      type: 'article',
-      images: resolveOpenGraphImage(
-        unitBusiness?.components?.[0]?.imageBackground
-      ),
-    },
-  };
+  return buildDocumentMetadata({
+    document: unitBusiness,
+    path: `/area-de-practica/${params.slug}`,
+    fallbackImage: unitBusiness?.components?.[0]?.imageBackground,
+  });
 }
 
 async function getData(slug: string) {
@@ -54,6 +51,7 @@ async function getData(slug: string) {
 
 export default async function Page({ params }: { params: { slug: string } }) {
   const unitBusinessPage = await getData(params.slug);
+  if (!unitBusinessPage?.unitBusiness) notFound();
   // add posts brief to Banner Posts
   unitBusinessPage?.unitBusiness?.components?.map((component) => {
     if (
@@ -68,9 +66,6 @@ export default async function Page({ params }: { params: { slug: string } }) {
     }
   });
 
-  if (!unitBusinessPage) {
-    return <div>Servicio no encontrado.</div>; // Manejo básico de errores
-  }
   return (
     <section>
       {unitBusinessPage?.unitBusiness?.components ? (

--- a/app/(web)/blog/[slug]/page.tsx
+++ b/app/(web)/blog/[slug]/page.tsx
@@ -4,8 +4,13 @@ import { getPostBySlugFetch } from '@/sanity/lib/fetchs/post.fetch';
 import PageTemplate from '@/components/pages/PageTemplate';
 import PortableTextAndToc from '@/components/pages/component/PortableTextAndToc';
 import { ComponentsProps } from '@/components/types';
-import { resolveOpenGraphImage } from '@/sanity/lib/utils';
-import { Service, WithContext } from 'schema-dts';
+import { BlogPosting, WithContext } from 'schema-dts';
+import {
+  buildDocumentMetadata,
+  serializeJsonLd,
+  type SeoDocument,
+} from '@/sanity/lib/seo';
+import { notFound } from 'next/navigation';
 
 export async function generateMetadata({
   params,
@@ -13,14 +18,14 @@ export async function generateMetadata({
   params: { slug: string };
 }): Promise<Metadata> {
   const post: GetPostDetailQueryResult = await getData(params.slug);
-  return {
-    title: post?.title,
-    openGraph: {
-      title: post?.title || '',
-      type: 'article',
-      images: resolveOpenGraphImage(post?.components?.[0]?.imageBackground),
-    },
-  };
+  if (!post) notFound();
+
+  return buildDocumentMetadata({
+    document: post,
+    path: `/blog/${params.slug}`,
+    fallbackImage: post?.coverImage || post?.components?.[0]?.imageBackground,
+    type: 'article',
+  });
 }
 
 async function getData(slug: string) {
@@ -37,36 +42,28 @@ async function getData(slug: string) {
 
 export default async function Page({ params }: { params: { slug: string } }) {
   const post = await getData(params.slug);
-  if (!post) {
-    return <div>Servicio no encontrado.</div>;
-  }
+  if (!post) notFound();
+  const seoPost = post as unknown as SeoDocument & {
+    author?: { name?: string | null } | null;
+  };
 
-  const jsonLd: WithContext<Service> = {
+  const jsonLd: WithContext<BlogPosting> = {
     '@context': 'https://schema.org',
-    '@type': 'Service',
+    '@type': 'BlogPosting',
     name: post?.title || 'Abogados San Felipe',
-    description: post.resumen || 'Derecho Familiar e Inmobiliario',
-    serviceType: 'Asesoría Legal y Jurídica',
-    provider: {
+    headline: post?.title || undefined,
+    description: seoPost.seo?.metaDescription || post.resumen || undefined,
+    datePublished: post.date || undefined,
+    dateModified: post._updatedAt || post.date || undefined,
+    author: seoPost.author?.name
+      ? { '@type': 'Person', name: seoPost.author.name }
+      : undefined,
+    publisher: {
       '@type': 'Organization',
       name: 'Abogados San Felipe - Sebastián Bonilla Marín',
-      address: {
-        '@type': 'PostalAddress',
-        addressLocality: 'San Felipe',
-        addressRegion: 'Valparaíso',
-        postalCode: '2170000',
-        addressCountry: 'CL',
-      },
-      telephone: '+56 9 3359 6955',
-      email: 'contacto@abogadossanfelipe.cl',
       url: 'https://www.abogadossanfelipe.cl',
     },
-    areaServed: 'San Felipe, Chile',
-    offers: {
-      '@type': 'Offer',
-      price: 'Consultar',
-      priceCurrency: 'CLP',
-    },
+    mainEntityOfPage: `https://www.abogadossanfelipe.cl/blog/${params.slug}`,
   };
   const breadcrumbsItems = [
     { label: 'Inicio', slug: 'home' },
@@ -77,7 +74,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
     <section>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
       />
       {post?.components && (
         <PageTemplate components={post.components as ComponentsProps} />

--- a/app/(web)/blog/page.tsx
+++ b/app/(web)/blog/page.tsx
@@ -11,7 +11,8 @@ import { getPostListFetch } from '@/sanity/lib/fetchs/post.fetch';
 import { getUnitBusinessListFetch } from '@/sanity/lib/fetchs/unitBusiness.fetch';
 import { ComponentProps, ComponentsProps } from '@/components/types';
 import Resources from '@/components/pages/component/Resources';
-import { resolveOpenGraphImage, urlForImage } from '@/sanity/lib/utils';
+import { buildDocumentMetadata } from '@/sanity/lib/seo';
+import { notFound } from 'next/navigation';
 
 type PageData = {
   page: GetPageDetailQueryResult | null;
@@ -27,14 +28,11 @@ export async function generateMetadata(): Promise<Metadata> {
     };
   }
   const { page } = data;
-  return {
-    title: 'Información Sobre Procedimientos Legales',
-    openGraph: {
-      title: page?.title || '',
-      type: 'article',
-      images: resolveOpenGraphImage(page?.components?.[0]?.imageBackground),
-    },
-  };
+  return buildDocumentMetadata({
+    document: page,
+    path: '/blog',
+    fallbackImage: page?.components?.[0]?.imageBackground,
+  });
 }
 
 async function getDataPage() {
@@ -44,9 +42,9 @@ async function getDataPage() {
       GetPostListQueryResult | null,
       GetUnitBusinessListQueryResult | null,
     ] = await Promise.all([
-      await getPageBySlugFetch('blog'),
-      await getPostListFetch(),
-      await getUnitBusinessListFetch(),
+      getPageBySlugFetch('blog'),
+      getPostListFetch(),
+      getUnitBusinessListFetch(),
     ]);
     return { page, posts, unitBusiness };
   } catch (error) {
@@ -57,9 +55,7 @@ async function getDataPage() {
 
 export default async function Page() {
   const data = await getDataPage();
-  if (!data) {
-    return <div>Error fetching data</div>;
-  }
+  if (!data?.page) notFound();
   const { page, posts, unitBusiness }: PageData = data;
   //console.log('page blog', page);
   return (

--- a/app/(web)/layout.tsx
+++ b/app/(web)/layout.tsx
@@ -11,33 +11,27 @@ import { draftMode } from 'next/headers';
 import { fonts } from '@/components/global/fonts';
 import DisableDraftMode from '@/components/global/DisableDraftMode';
 import ErrorBoundary from '@/components/ErrorBoundary';
-import { Suspense } from 'react';
-import { Spinner } from '@/components/global/Spinner';
 import Providers from '@/context/Providers';
 import { getPagesNavFetch } from '@/sanity/lib/fetchs/page.fetch';
-import { getComponentListFetch } from '@/sanity/lib/fetchs/component.fetch';
 import { getUnitBusinessListFetch } from '@/sanity/lib/fetchs/unitBusiness.fetch';
 import WhatsappSticky from '@/components/global/WhatsappSticky';
 import Form from '@/components/global/Form';
 import { Metadata } from 'next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import { GoogleTagManager } from '@next/third-parties/google';
-import { resolveOpenGraphImage, urlForImage } from '@/sanity/lib/utils';
+import { getSiteUrl } from '@/sanity/lib/seo';
+import { resolveOpenGraphImage } from '@/sanity/lib/utils';
 
 export async function generateMetadata(): Promise<Metadata> {
-  const data = await getData();
-  const { settings } = data;
+  const settings = await getSettingsFetch();
+  const siteUrl = getSiteUrl(settings?.metaBaseWebsite);
+  const siteName = settings?.title || 'Abogados San Felipe';
+
   return {
-    metadataBase: new URL(
-      `https://${
-        process.env.NODE_ENV == 'development'
-          ? 'localhost:3000'
-          : settings?.metaBaseWebsite
-      }`
-    ), // URL base
+    metadataBase: new URL(siteUrl),
     title: {
-      template: '%s ' + settings?.templateTitle,
-      default: settings?.templateTitle || '',
+      template: `%s | ${settings?.templateTitle || siteName}`,
+      default: siteName,
     },
     generator: 'Next.js',
     keywords: [
@@ -53,7 +47,8 @@ export async function generateMetadata(): Promise<Metadata> {
       'herencias y testamentos San Felipe',
     ],
     description: settings?.description,
-    publisher: 'Vercel',
+    applicationName: siteName,
+    publisher: siteName,
     robots: {
       index: true,
       follow: true,
@@ -76,9 +71,19 @@ export async function generateMetadata(): Promise<Metadata> {
       ],
     },
     openGraph: {
-      title: settings?.title || '',
+      title: siteName,
+      description: settings?.description,
       images: resolveOpenGraphImage(settings?.ogImage),
+      locale: 'es_CL',
+      siteName,
       type: 'website',
+      url: '/',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: siteName,
+      description: settings?.description,
+      images: resolveOpenGraphImage(settings?.ogImage),
     },
   };
 }
@@ -86,18 +91,15 @@ export async function generateMetadata(): Promise<Metadata> {
 // Async function to fetch data
 async function getData(): Promise<SanityContextType> {
   try {
-    const [pages, componentsMap, unitBusinessList, settings] =
-      await Promise.all([
-        getPagesNavFetch(),
-        getComponentListFetch(),
-        getUnitBusinessListFetch(),
-        getSettingsFetch(),
-      ]);
+    const [pages, unitBusinessList, settings] = await Promise.all([
+      getPagesNavFetch(),
+      getUnitBusinessListFetch(),
+      getSettingsFetch(),
+    ]);
     if (!pages) throw new Error('Failed to fetch pages');
-    if (!componentsMap) throw new Error('Failed to fetch components');
     if (!unitBusinessList) throw new Error('Failed to fetch unit business');
     if (!settings) throw new Error('Failed to fetch settings');
-    return { pages, componentsMap, unitBusinessList, settings };
+    return { pages, unitBusinessList, settings };
   } catch (error) {
     console.error('Failed to fetch data:', error);
     throw new Error('Failed to fetch necessary data for the application');
@@ -109,73 +111,58 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  try {
-    const { pages, componentsMap, unitBusinessList, settings } =
-      await getData();
-    if (!pages || !componentsMap || !unitBusinessList || !settings) {
-      throw new Error('Essential data is missing');
-    }
+  const { pages, unitBusinessList, settings } = await getData();
+  if (!pages || !unitBusinessList || !settings) {
+    throw new Error('Essential data is missing');
+  }
 
-    const initialData: SanityContextType = {
-      componentsMap,
-      pages,
-      unitBusinessList,
-      settings,
-    };
+  const initialData: SanityContextType = {
+    pages,
+    unitBusinessList,
+    settings,
+  };
 
-    const { isEnabled } = draftMode();
+  const { isEnabled } = draftMode();
 
-    return (
-      <html
-        lang="es"
-        className={`${Object.values(fonts)
-          .map((font) => font.variable)
-          .join(' ')} scroll-smooth`}
-      >
-        <head>
-          <DarkModeScript />
-        </head>
+  return (
+    <html
+      lang="es"
+      className={`${Object.values(fonts)
+        .map((font) => font.variable)
+        .join(' ')} scroll-smooth`}
+    >
+      <head>
+        <DarkModeScript />
+      </head>
+
+      <body className="min-h-screen min-w-[320px] flex-col">
         <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GTM_ID || ''} />
         <GTMGlobals />
+        <ErrorBoundary>
+          <Providers
+            initialData={initialData}
+            withDarkMode={settings.withDarkTheme || false}
+          >
+            <Navbar />
+            <main className="grow flex-col">
+              {children}
+              <SpeedInsights />
+              <Form />
 
-        <body className="min-h-screen min-w-[320px] flex-col">
-          <ErrorBoundary>
-            <Suspense fallback={<Spinner />}>
-              <Providers initialData={initialData} withDarkMode={false}>
-                <Navbar />
-                <main className="grow flex-col">
-                  {children}
-                  <SpeedInsights />
-                  <Form />
+              <WhatsappSticky />
+              <SanityLive />
 
-                  <WhatsappSticky />
-                  {process.env.NODE_ENV === 'development' && <SanityLive />}
-
-                  {isEnabled && (
-                    <>
-                      <DisableDraftMode />
-                      <VisualEditing />
-                    </>
-                  )}
-                </main>
-                <Footer />
-              </Providers>
-            </Suspense>
-          </ErrorBoundary>
-        </body>
-      </html>
-    );
-  } catch (error) {
-    console.error('Error in RootLayout:', error);
-    return (
-      <html lang="es">
-        <body>
-          <div className="error-message">
-            An error occurred while loading the application. Please try again
-            later.
-          </div>
-        </body>
-      </html>
-    );
-  }
+              {isEnabled && (
+                <>
+                  <DisableDraftMode />
+                  <VisualEditing />
+                </>
+              )}
+            </main>
+            <Footer />
+          </Providers>
+        </ErrorBoundary>
+      </body>
+    </html>
+  );
 }

--- a/app/(web)/page.tsx
+++ b/app/(web)/page.tsx
@@ -9,15 +9,20 @@ import { getPageBySlugFetch } from '@/sanity/lib/fetchs/page.fetch';
 import { getPostListFetch } from '@/sanity/lib/fetchs/post.fetch';
 import { Metadata } from 'next';
 import { Service, WithContext } from 'schema-dts';
+import { buildDocumentMetadata, serializeJsonLd } from '@/sanity/lib/seo';
+import { notFound } from 'next/navigation';
 
 type PageData = {
   home: GetPageDetailQueryResult | null;
   posts: GetPostListQueryResult | null;
 };
 export async function generateMetadata(): Promise<Metadata> {
-  return {
-    title: 'Sebastián Bonilla | Abogados',
-  };
+  const home = await getPageBySlugFetch('inicio');
+  return buildDocumentMetadata({
+    document: home,
+    path: '/',
+    fallbackImage: home?.components?.[0]?.imageBackground,
+  });
 }
 async function getData(slug: string) {
   try {
@@ -38,6 +43,7 @@ export type ModifiedComponent = ComponentWithBannerPosts & {
 
 export default async function Page() {
   const currentPage = await getData('inicio');
+  if (!currentPage?.home) notFound();
 
   const jsonLd: WithContext<Service> = {
     '@context': 'https://schema.org',
@@ -66,9 +72,6 @@ export default async function Page() {
       priceCurrency: 'CLP',
     },
   };
-  if (!currentPage) {
-    return <div>Error al cargar la página.</div>;
-  }
   // Crear una copia de los componentes para evitar mutaciones directas
   const { home, posts }: PageData = currentPage;
 
@@ -91,7 +94,7 @@ export default async function Page() {
     <section>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
       />
       {componentsAndPosts && (
         <PageTemplate components={componentsAndPosts as ModifiedComponent} />

--- a/app/(web)/services/[slug]/page.tsx
+++ b/app/(web)/services/[slug]/page.tsx
@@ -5,8 +5,9 @@ import { getServiceBySlugFetch } from '@/sanity/lib/fetchs/service.fetch';
 import PortableTextAndToc from '@/components/pages/component/PortableTextAndToc';
 import { Metadata } from 'next';
 import { ComponentProps } from '@/components/types';
-import { resolveOpenGraphImage } from '@/sanity/lib/utils';
 import { Service, WithContext } from 'schema-dts';
+import { buildDocumentMetadata, serializeJsonLd } from '@/sanity/lib/seo';
+import { notFound } from 'next/navigation';
 
 export async function generateMetadata({
   params,
@@ -14,13 +15,13 @@ export async function generateMetadata({
   params: { slug: string };
 }): Promise<Metadata> {
   const service: GetServiceDetailQueryResult = await getData(params.slug);
-  return {
-    title: service?.title,
-    description: service?.resumen,
-    openGraph: {
-      images: resolveOpenGraphImage(service?.components?.[0]?.imageBackground),
-    },
-  };
+  if (!service) notFound();
+
+  return buildDocumentMetadata({
+    document: service,
+    path: `/services/${params.slug}`,
+    fallbackImage: service?.components?.[0]?.imageBackground,
+  });
 }
 
 async function getData(slug: string): Promise<GetServiceDetailQueryResult> {
@@ -35,9 +36,7 @@ async function getData(slug: string): Promise<GetServiceDetailQueryResult> {
 
 export default async function Page({ params }: { params: { slug: string } }) {
   const service = await getData(params?.slug);
-  if (!service) {
-    return <div>Servicio no encontrado.</div>; // Manejo básico de errores
-  }
+  if (!service) notFound();
 
   const jsonLd: WithContext<Service> = {
     '@context': 'https://schema.org',
@@ -78,7 +77,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
     <section>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
       />
       <div className={'mx-auto'}>
         {service?.components && (

--- a/app/api/email/route.tsx
+++ b/app/api/email/route.tsx
@@ -14,52 +14,57 @@ type Article = {
   message: string;
 };
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+let resend: Resend | undefined;
+
+function getResend() {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) throw new Error('Missing RESEND_API_KEY');
+  resend ??= new Resend(apiKey);
+  return resend;
+}
 
 export async function POST(request: NextRequest) {
-  const {
-    name,
-    rut,
-    phone,
-    comuna,
-    email,
-    mainCategory,
-    serviceCategory,
-    message,
-  }: Article = await request.json();
-
-  // Esperar a que el HTML del correo sea generado correctamente
-  const emailHtml = await render(
-    <Email
-      name={name}
-      rut={rut}
-      phone={phone}
-      comuna={comuna}
-      email={email}
-      mainCategory={mainCategory}
-      serviceCategory={serviceCategory}
-      message={message}
-    />
-  );
-
   try {
-    // Enviar el correo electrónico
-    const response = await resend.emails.send({
-      from: process.env.SENDER_EMAIL || '',
-      to: process.env.CLIENT_EMAIL || '',
+    const {
+      name,
+      rut,
+      phone,
+      comuna,
+      email,
+      mainCategory,
+      serviceCategory,
+      message,
+    }: Article = await request.json();
+    const sender = process.env.SENDER_EMAIL;
+    const recipient = process.env.CLIENT_EMAIL;
+    if (!sender || !recipient) {
+      throw new Error('Missing sender or recipient email configuration');
+    }
+
+    const emailHtml = await render(
+      <Email
+        name={name}
+        rut={rut}
+        phone={phone}
+        comuna={comuna}
+        email={email}
+        mainCategory={mainCategory}
+        serviceCategory={serviceCategory}
+        message={message}
+      />
+    );
+
+    const response = await getResend().emails.send({
+      from: sender,
+      to: recipient,
       subject: `SBA-cliente: ${name} Servicio: ${mainCategory}`,
-      html: emailHtml, // Ya es un string aquí
+      html: emailHtml,
     });
 
-    // Imprimir la respuesta de la API para obtener más detalles
-
-    return NextResponse.json({ status: 200, response });
+    return NextResponse.json({ response });
   } catch (error) {
-    // Comprobación de tipo para asegurarse de que 'error' es un objeto de tipo 'Error'
-    if (error instanceof Error) {
-      return NextResponse.json({ status: 500, error: error.message });
-    } else {
-      return NextResponse.json({ status: 500, error: 'Error desconocido' });
-    }
+    const message =
+      error instanceof Error ? error.message : 'Error desconocido';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,11 +1,13 @@
-import { MetadataRoute } from 'next'
- 
+import { MetadataRoute } from 'next';
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: '*',
       allow: '/',
+      disallow: ['/studio/', '/api/'],
     },
     sitemap: 'https://www.abogadossanfelipe.cl/sitemap.xml',
-  }
+    host: 'https://www.abogadossanfelipe.cl',
+  };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,86 +1,65 @@
-import { getSettingsFetch } from '@/sanity/lib/fetch';
-import { getPostListFetch } from '@/sanity/lib/fetchs/post.fetch';
-import { getServicesNavFetch } from '@/sanity/lib/fetchs/service.fetch';
 import { MetadataRoute } from 'next';
-import { getUnitBusinessListFetch } from '@/sanity/lib/fetchs/unitBusiness.fetch';
-import {
-  GetPostListQueryResult,
-  GetServicesNavQueryResult,
-  GetUnitBusinessListQueryResult,
-  SettingsQueryResult,
-} from '@/sanity.types';
+import { getSettingsFetch } from '@/sanity/lib/fetch';
+import { getSitemapFetch } from '@/sanity/lib/fetchs/sitemap.fetch';
+import { getSiteUrl } from '@/sanity/lib/seo';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const [settings, services, posts, unitBusiness]: [
-    SettingsQueryResult | null,
-    GetServicesNavQueryResult | null,
-    GetPostListQueryResult | null,
-    GetUnitBusinessListQueryResult | null,
-  ] = await Promise.all([
+  const [settings, content] = await Promise.all([
     getSettingsFetch(),
-    getServicesNavFetch(),
-    getPostListFetch(),
-    getUnitBusinessListFetch(),
+    getSitemapFetch(),
   ]);
-  const baseUrl = `https://${
-    process.env.NODE_ENV === 'development'
-      ? 'localhost:3000'
-      : settings?.metaBaseWebsite
-  }`;
-  const servicesPages = services?.map((service) => ({
-    url: `${baseUrl}/services/${service.slug}`,
-    lastModified: new Date(),
-    changeFrequency: 'monthly' as const,
-    priority: 0.8,
+  const baseUrl = getSiteUrl(settings?.metaBaseWebsite);
+
+  const pages: MetadataRoute.Sitemap = (content.pages || []).map((page) => ({
+    url: page.isHome ? baseUrl : `${baseUrl}/${page.slug}`,
+    lastModified: page._updatedAt,
+    changeFrequency: page.isHome ? 'weekly' : 'monthly',
+    priority: page.isHome ? 1 : 0.8,
   }));
 
-  const postsPages = posts?.map((post) => ({
+  const posts: MetadataRoute.Sitemap = (content.posts || []).map((post) => ({
     url: `${baseUrl}/blog/${post.slug}`,
-    lastModified: new Date(),
-    changeFrequency: 'monthly' as const,
-    priority: 0.5,
+    lastModified: post._updatedAt,
+    changeFrequency: 'monthly',
+    priority: 0.6,
   }));
 
-  const unitBusinessPages = unitBusiness?.map((unitBusiness) => ({
-    url: `${baseUrl}/area-de-practica/${unitBusiness.slug}`,
-    lastModified: new Date(),
-    changeFrequency: 'monthly' as const,
-    priority: 0.8,
-  }));
+  const services: MetadataRoute.Sitemap = (content.services || []).map(
+    (service) => ({
+      url: `${baseUrl}/services/${service.slug}`,
+      lastModified: service._updatedAt,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    })
+  );
 
-  return [
+  const unitBusiness: MetadataRoute.Sitemap = (content.unitBusiness || []).map(
+    (unit) => ({
+      url: `${baseUrl}/area-de-practica/${unit.slug}`,
+      lastModified: unit._updatedAt,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    })
+  );
+
+  const fallbackPages: MetadataRoute.Sitemap = [
     {
       url: baseUrl,
-      lastModified: new Date(),
-      changeFrequency: 'yearly',
+      changeFrequency: 'weekly',
       priority: 1,
     },
     {
-      url: `${baseUrl}/nosotros`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/services`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
       url: `${baseUrl}/blog`,
-      lastModified: new Date(),
       changeFrequency: 'weekly',
-      priority: 0.5,
+      priority: 0.7,
     },
-    {
-      url: `${baseUrl}/contacto`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.5,
-    },
-    ...(servicesPages || []),
-    ...(postsPages || []),
-    ...(unitBusinessPages || []),
   ];
+
+  return Array.from(
+    new Map(
+      [...fallbackPages, ...pages, ...services, ...unitBusiness, ...posts].map(
+        (entry) => [entry.url, entry]
+      )
+    ).values()
+  );
 }

--- a/components/global/fonts.tsx
+++ b/components/global/fonts.tsx
@@ -1,40 +1,7 @@
-import {
-  Inter,
-  Roboto_Flex,
-  Roboto_Slab,
-  Roboto_Mono,
-  Crimson_Pro,
-  Montserrat,
-  Bitter,
-  Fira_Sans,
-} from 'next/font/google';
-
-const inter = Inter({
-  variable: '--font-inter',
-  subsets: ['latin'],
-  display: 'swap',
-});
-
-const roboto_flex = Roboto_Flex({
-  variable: '--font-roboto-flex',
-  subsets: ['latin'],
-  display: 'swap',
-});
-
-const roboto_slab = Roboto_Slab({
-  variable: '--font-roboto-slab',
-  subsets: ['latin'],
-  display: 'swap',
-});
+import { Roboto_Mono, Montserrat, Bitter } from 'next/font/google';
 
 const roboto_mono = Roboto_Mono({
   variable: '--font-roboto-mono',
-  subsets: ['latin'],
-  display: 'swap',
-});
-
-const crimson_pro = Crimson_Pro({
-  variable: '--font-crimson-pro',
   subsets: ['latin'],
   display: 'swap',
 });
@@ -51,20 +18,8 @@ const bitter = Bitter({
   display: 'swap',
 });
 
-const fira_sans = Fira_Sans({
-  variable: '--font-fira-sans',
-  subsets: ['latin'],
-  display: 'swap',
-  weight: ['100', '200', '300', '400', '500', '600', '700', '800', '900'],
-});
-
 export const fonts = {
-  inter,
-  roboto_flex,
-  roboto_slab,
   roboto_mono,
-  crimson_pro,
   montserrat,
   bitter,
-  fira_sans,
 };

--- a/components/pages/PageTemplate.tsx
+++ b/components/pages/PageTemplate.tsx
@@ -1,83 +1,76 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { memo, useEffect, useMemo } from 'react';
-import { useLoadingContext } from '@/context/LoadingContext';
+import { ComponentType } from 'react';
 import getComponentSkeleton from '@/components/pages/skeletons/utils/getComponentSkeleton';
-import { Spinner } from '@/components/global/Spinner';
 import { ComponentProps, ComponentsProps } from '@/components/types';
 
-// Types
-interface LoadedComponent {
-  Component: React.ComponentType<{ data: ComponentProps }>;
-  data: ComponentProps;
+type PageBuilderComponent = ComponentType<{ data: ComponentProps }>;
+
+function loadComponent(
+  type: string,
+  loader: () => Promise<{ default: ComponentType<any> }>,
+  variant?: string
+) {
+  return dynamic(loader, {
+    loading: () => {
+      const Skeleton = getComponentSkeleton(type, variant);
+      return <Skeleton />;
+    },
+  });
 }
 
-// Functions
-const getDynamicComponent = (type: string, variant?: string) =>
-  dynamic<{ data: ComponentProps }>(
-    () =>
-      import(`@/components/pages/component/${type}`).catch(
-        () => import('@/components/pages/component/Default')
-      ),
-    {
-      ssr: false,
-      loading: () => {
-        const Skeleton = getComponentSkeleton(type, variant);
-        return <Skeleton />;
-      },
-    }
-  );
+const componentRegistry: Record<string, PageBuilderComponent> = {
+  Banner1: loadComponent('Banner1', () => import('./component/Banner1')),
+  Banner2: loadComponent('Banner2', () => import('./component/Banner2')),
+  Banner4Images: loadComponent(
+    'Banner4Images',
+    () => import('./component/Banner4Images')
+  ),
+  BannerList: loadComponent(
+    'BannerList',
+    () => import('./component/BannerList')
+  ),
+  BannerPosts: loadComponent(
+    'BannerPosts',
+    () => import('./component/BannerPosts')
+  ),
+  BannerServices: loadComponent(
+    'BannerServices',
+    () => import('./component/BannerServices')
+  ),
+  BannerWithItems: loadComponent(
+    'BannerWithItems',
+    () => import('./component/BannerWithItems')
+  ),
+  Carousel: loadComponent('Carousel', () => import('./component/Carousel')),
+  Heading: loadComponent('Heading', () => import('./component/Heading')),
+  HeroForm: loadComponent('HeroForm', () => import('./component/HeroForm')),
+  HeroImage: loadComponent('HeroImage', () => import('./component/HeroImage')),
+  HeroVideo: loadComponent('HeroVideo', () => import('./component/HeroVideo')),
+  HighLight: loadComponent('HighLight', () => import('./component/HighLight')),
+  Resources: loadComponent('Resources', () => import('./component/Resources')),
+};
 
-// Memoized Component
-const MemoizedComponent = memo(({ Component, data }: LoadedComponent) => (
-  <Component data={data} />
-));
-MemoizedComponent.displayName = 'MemoizedComponent';
+const DefaultComponent = dynamic<{ data: ComponentProps }>(
+  () => import('./component/Default')
+);
 
-// Main Component
+const getDynamicComponent = (type: string) =>
+  componentRegistry[type] || DefaultComponent;
+
 const PageTemplate = ({ components }: { components?: ComponentsProps }) => {
-  const { isLoading, setLoading, setComponents } = useLoadingContext();
-
-  // Effect to handle loading state and components
-  useEffect(() => {
-    if (components) {
-      setComponents(components);
-      setLoading(false);
-    }
-  }, [components, setComponents, setLoading]);
-
-  // Memoized loaded components
-  const loadedComponents = useMemo(
-    () =>
-      components?.map((component: ComponentProps) => ({
-        data: component,
-        Component: getDynamicComponent(
-          component.typeComponentValue,
-          component.variant
-        ),
-      })) || [],
-    [components]
-  );
-
-  // Loading state
-  if (isLoading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <Spinner />
-      </div>
-    );
-  }
-
-  // Main render
   return (
     <div className="opacity-100 transition-opacity duration-300">
-      {loadedComponents.map((props: LoadedComponent, index: number) => (
-        <MemoizedComponent
-          key={`component-${index}-${props.data.typeComponentValue}`}
-          {...props}
-        />
-      ))}
+      {components?.map((data: ComponentProps, index: number) => {
+        const Component = getDynamicComponent(data.typeComponentValue);
+        const key =
+          '_key' in data && data._key
+            ? data._key
+            : `${data.typeComponentValue}-${index}`;
+
+        return <Component key={key} data={data} />;
+      })}
     </div>
   );
 };

--- a/components/pages/component/Background/ImageBg.tsx
+++ b/components/pages/component/Background/ImageBg.tsx
@@ -17,10 +17,11 @@ export default function ImageBg({
       {imgBg && imgBgType === 'dynamic' && (
         <Image
           src={urlForImage(imgBg)?.url() || '/meeting.jpeg'}
-          alt="Hero image for the homepage"
+          alt=""
           className="inset-0 z-10 size-full object-cover object-center"
           quality={70}
           fill
+          sizes="100vw"
           priority={priority}
         />
       )}

--- a/components/pages/component/Background/PTextHero.tsx
+++ b/components/pages/component/Background/PTextHero.tsx
@@ -4,51 +4,6 @@ import clsx from 'clsx';
 import Link from 'next/link';
 import { trackButtonClick } from '@/components/lib/GTMTrackers';
 
-// Define PT1 and PT2 components
-const PT1: PortableTextComponents = {
-  block: {
-    h1: ({ children }) => (
-      <h1
-        className={clsx(
-          'font-bitter text-2xl font-extralight uppercase text-white drop-shadow-2xl',
-          'lg:text-3xl',
-          '2xl:text-3xl'
-        )}
-      >
-        {children}
-      </h1>
-    ),
-    h2: ({ children }) => (
-      <h2
-        className={clsx(
-          'font-bitter text-2xl font-extralight uppercase text-white drop-shadow-2xl',
-          'lg:text-3xl',
-          '2xl:text-3xl'
-        )}
-      >
-        {children}
-      </h2>
-    ),
-    normal: ({ children }) => (
-      <span
-        className={clsx(
-          'mt-3 font-crimson text-lg font-thin leading-5 text-white',
-          'md:mt-5 lg:text-2xl'
-        )}
-      >
-        {children}
-      </span>
-    ),
-  },
-  marks: {
-    strong: ({ children }) => (
-      <span className="p3 drop-shadow-4xl font-extrabold text-red-700">
-        {children}
-      </span>
-    ),
-  },
-};
-
 export default function PTextHero({
   data,
   index,
@@ -56,6 +11,51 @@ export default function PTextHero({
   data: ComponentProps;
   index?: number;
 }) {
+  const PrimaryHeading = index === 0 ? 'h1' : 'h2';
+  const components: PortableTextComponents = {
+    block: {
+      h1: ({ children }) => (
+        <PrimaryHeading
+          className={clsx(
+            'font-bitter text-2xl font-extralight uppercase text-white drop-shadow-2xl',
+            'lg:text-3xl',
+            '2xl:text-3xl'
+          )}
+        >
+          {children}
+        </PrimaryHeading>
+      ),
+      h2: ({ children }) => (
+        <h2
+          className={clsx(
+            'font-bitter text-2xl font-extralight uppercase text-white drop-shadow-2xl',
+            'lg:text-3xl',
+            '2xl:text-3xl'
+          )}
+        >
+          {children}
+        </h2>
+      ),
+      normal: ({ children }) => (
+        <span
+          className={clsx(
+            'mt-3 font-crimson text-lg font-thin leading-5 text-white',
+            'md:mt-5 lg:text-2xl'
+          )}
+        >
+          {children}
+        </span>
+      ),
+    },
+    marks: {
+      strong: ({ children }) => (
+        <span className="p3 drop-shadow-4xl font-extrabold text-red-700">
+          {children}
+        </span>
+      ),
+    },
+  };
+
   return (
     <div className="absolute inset-0 flex items-center justify-center text-center">
       <div
@@ -66,7 +66,7 @@ export default function PTextHero({
       >
         <PortableText
           value={data.content || []} // Renderiza el contenido si está disponible
-          components={PT1} // Usamos el componente adecuado, con valor por defecto
+          components={components} // Usamos el componente adecuado, con valor por defecto
         />
         <Link href={{ pathname: data.ctaLinkItem }} passHref>
           <button

--- a/components/pages/component/Banner1/index.tsx
+++ b/components/pages/component/Banner1/index.tsx
@@ -56,7 +56,8 @@ export default function Banner1({ data }: { data: ComponentProps }) {
         <Image
           src={urlForImage(imageContent)?.url() || '/meeting.jpeg'}
           fill
-          alt="Banner Image"
+          alt={imageContent?.alt || ''}
+          sizes="(max-width: 1023px) 100vw, 33vw"
           className="absolute inset-0 object-cover"
         />
       </div>

--- a/components/pages/component/Banner4Images/Card.tsx
+++ b/components/pages/component/Banner4Images/Card.tsx
@@ -27,7 +27,7 @@ export default function Card({
       >
         <Image
           src={urlForImage(service.image)?.url() || '/meeting.jpeg'}
-          alt={'title'}
+          alt={service.alt || ''}
           fill
           sizes="(max-width: 768px) 100vw, (max-width: 1023px) 50vw, 33.33vw"
           className="object-cover transition-transform duration-300 group-hover:scale-110"

--- a/components/pages/component/BannerServices/index.tsx
+++ b/components/pages/component/BannerServices/index.tsx
@@ -63,7 +63,7 @@ export default function BannerServices({ data }: { data: ComponentProps }) {
         <div className="absolute inset-x-0 bottom-0 flex h-1/2 items-start">
           <div className="relative z-0 h-full w-full">
             <Image
-              src={urlForImage(data.imageBackground)?.url()}
+              src={urlForImage(data.imageBackground)?.url() || '/meeting.jpeg'}
               alt="vec1"
               fill
               className="object-cover"

--- a/components/pages/component/BannerWithItems/InnerBannerWithItems.tsx
+++ b/components/pages/component/BannerWithItems/InnerBannerWithItems.tsx
@@ -50,7 +50,7 @@ export default function InnerBannerWithItems({
           imagePosition={data.imagePosition}
         />
         <ImageItem
-          src={urlForImage(data.image)?.url()}
+          src={urlForImage(data.image)?.url() || '/meeting.jpeg'}
           imagePosition={data.imagePosition}
         />
       </div>

--- a/components/pages/component/BannerWithItems/ItemBanner1.tsx
+++ b/components/pages/component/BannerWithItems/ItemBanner1.tsx
@@ -6,6 +6,8 @@ import PTItemBanner, {
   type PTItemtype,
 } from '@/components/pages/component/BannerWithItems/PTextItemBanner';
 import { IconsList } from '@/sanity.types';
+import Image from 'next/image';
+import { urlForImage } from '@/sanity/lib/utils';
 
 export default function ItemBanner1({
   item,
@@ -23,8 +25,8 @@ export default function ItemBanner1({
 
   const hasSvgIconList: IconsList = item.svgIconList;
   const hasSvgIcon: string = item.svgIcon;
-  const hasImage: boolean = item.image;
-  
+  const imageUrl = urlForImage(item.image)?.url();
+
   return (
     <div className="hover:border-1 mb-10 flex h-full flex-col items-start rounded-3xl border-gray-300 text-center hover:cursor-pointer hover:shadow-lg xs4:h-72 md:mb-0">
       {/* Contenedor de íconos o imágenes */}
@@ -61,21 +63,25 @@ export default function ItemBanner1({
         )}
 
         {/* Si no hay SVGs ni lista, mostramos una imagen por defecto */}
-        {!hasSvgIcon && !hasSvgIconList && (
-          <img
+        {!hasSvgIcon && !hasSvgIconList && !imageUrl && (
+          <Image
             src="/intranet.svg"
-            alt="Imagen de ejemplo"
+            alt=""
+            width={48}
+            height={48}
             className="h-auto w-full"
           />
         )}
 
         {/* Mostrar la imagen si está disponible */}
-        {hasImage && !hasSvgIconList && !hasSvgIcon && (
+        {imageUrl && !hasSvgIconList && !hasSvgIcon && (
           <div className="relative flex h-[100px] w-full max-w-[100px] justify-center text-white">
-            <img
-              src={'/intranet.svg'}
-              alt="Imagen del ítem"
-              className="h-full w-full rounded-lg object-cover"
+            <Image
+              src={imageUrl}
+              alt={item.alt || ''}
+              fill
+              sizes="100px"
+              className="rounded-lg object-cover"
             />
           </div>
         )}

--- a/components/pages/component/Carousel/SlidePost.tsx
+++ b/components/pages/component/Carousel/SlidePost.tsx
@@ -14,31 +14,27 @@ export default function SlidePost({
   post: GetPostListQueryResult[number];
 }) {
   const path = usePathname();
-  if (!post.components) return null;
-
-  const { imageBackground } =
-    post.components.find(
-      (component) => component.typeComponentValue === 'Heading'
-    ) || {};
   return (
     <div className="group relative h-fit w-full items-center overflow-hidden px-1">
       <Link
-        href={{ pathname: `/blog/${post.slug?.current}` }}
+        href={{ pathname: `/blog/${post.slug}` }}
         className="group"
         onClick={() =>
-          trackButtonClick(
-            post.slug?.current || '',
-            'CarouselPost' + '-' + path
-          )
+          trackButtonClick(post.slug || '', 'CarouselPost' + '-' + path)
         }
       >
         <article className="flex h-full min-h-[420px] flex-col overflow-hidden rounded-xl bg-white shadow-md transition-shadow hover:shadow-lg">
           <div className="grid">
             <div className="relative h-48 overflow-hidden">
               <Image
-                src={urlForImage(imageBackground)?.url() || '/meeting.jpeg'}
-                alt={post.title || ''}
+                src={urlForImage(post.coverImage)?.url() || '/meeting.jpeg'}
+                alt={
+                  (post.coverImage as { alt?: string } | null)?.alt ||
+                  post.title ||
+                  ''
+                }
                 fill
+                sizes="(max-width: 768px) 90vw, (max-width: 1200px) 45vw, 360px"
                 className="object-cover transition-transform duration-300 ease-out group-hover:scale-110"
               />
             </div>

--- a/components/pages/component/Carousel/types.ts
+++ b/components/pages/component/Carousel/types.ts
@@ -12,7 +12,7 @@ export type ItemProps = {
 // Props para el carrusel principal
 export type CarouselProps = {
   data?: ComponentProps;
-  options: EmblaOptionsType;
+  options?: EmblaOptionsType;
   autoplayOptions?: {
     delay?: number;
     stopOnInteraction?: boolean;

--- a/components/pages/component/HeroImage/PTHeroImage.tsx
+++ b/components/pages/component/HeroImage/PTHeroImage.tsx
@@ -31,14 +31,14 @@ const PT1: PortableTextComponents = {
 const PT2: PortableTextComponents = {
   block: {
     h1: ({ children }) => (
-      <div className="mb-2 font-bitter text-3xl font-medium text-black md:text-5xl lg:mb-6">
-        <span>{children}</span>
-      </div>
-    ),
-    h2: ({ children }) => (
-      <h1 className="pr-10 font-montserrat text-xl font-medium text-white drop-shadow-2xl md:w-full md:text-2xl lg:text-3xl">
+      <h1 className="mb-2 font-bitter text-3xl font-medium text-black md:text-5xl lg:mb-6">
         {children}
       </h1>
+    ),
+    h2: ({ children }) => (
+      <h2 className="pr-10 font-montserrat text-xl font-medium text-white drop-shadow-2xl md:w-full md:text-2xl lg:text-3xl">
+        {children}
+      </h2>
     ),
   },
   marks: {

--- a/components/pages/component/HeroImage/index.tsx
+++ b/components/pages/component/HeroImage/index.tsx
@@ -31,10 +31,11 @@ export default function HeroImage({ data }: { data: ComponentProps }) {
     <section className="relative h-[70vh] w-full">
       <Image
         src={urlForImage(image)?.url() || '/meeting.jpeg'}
-        alt="Hero image for the homepage"
+        alt={(image as { alt?: string } | undefined)?.alt || ''}
         className="object-cover object-top"
-        quality={100}
+        quality={80}
         fill
+        sizes="100vw"
         priority
       />
       <div className="absolute inset-0 bg-red-700/60" />

--- a/components/pages/component/PTextComponents.tsx
+++ b/components/pages/component/PTextComponents.tsx
@@ -24,9 +24,9 @@ export const PTextBannerLight: PortableTextComponents = {
 export const PTextBannerDark: PortableTextComponents = {
   block: {
     h1: ({ children }) => (
-      <h2 className="mb-4 font-robotoslab text-2xl font-light uppercase text-white drop-shadow-sm lg:text-3xl">
+      <h1 className="mb-4 font-robotoslab text-2xl font-light uppercase text-white drop-shadow-sm lg:text-3xl">
         {children}
-      </h2>
+      </h1>
     ),
     normal: ({ children }) => (
       <p className="mx-auto text-center text-base font-light text-white/90">

--- a/components/pages/component/Posts/ItemPostList.tsx
+++ b/components/pages/component/Posts/ItemPostList.tsx
@@ -12,24 +12,21 @@ export default function ItemPostList({
   post: GetPostListQueryResult[number];
   index: number;
 }) {
-  //console.log('post: ', post);
   const path = usePathname();
-  if (!post.components) return null;
-  console.log('path: ', path);
-  const { imageBackground } =
-    post.components.find(
-      (component) => component.typeComponentValue === 'Heading'
-    ) || {};
-  const isPriority = false; // Solo las primeras 5 imágenes son priority
+  const isPriority = index === 0;
   return (
-    <Link href={{ pathname: `/blog/${post.slug?.current}` }} className="group">
+    <Link href={{ pathname: `/blog/${post.slug}` }} className="group">
       <article className="overflow-hidden rounded-xl bg-white shadow-md transition-shadow hover:shadow-lg">
         <div className="grid gap-4 md:grid-cols-[300px_1fr]">
           <div className="h-48 overflow-hidden md:h-full">
             <div className="relative flex size-full">
               <Image
-                src={urlForImage(imageBackground)?.url() || '/meeting.jpeg'}
-                alt={post.title || ''}
+                src={urlForImage(post.coverImage)?.url() || '/meeting.jpeg'}
+                alt={
+                  (post.coverImage as { alt?: string } | null)?.alt ||
+                  post.title ||
+                  ''
+                }
                 fill
                 sizes="(max-width: 640px) 100vw, (max-width: 1028px) 50vw, 300px"
                 className="object-cover transition-transform duration-300 ease-out group-hover:scale-110"

--- a/components/pages/component/Posts/PTextPost.tsx
+++ b/components/pages/component/Posts/PTextPost.tsx
@@ -56,9 +56,11 @@ export const PTextPost: PortableTextComponents = {
       return (
         <div className="relative my-5 max-h-[500px] min-h-[350px] w-full overflow-hidden">
           <Image
-            alt={value.alt || 'Descripción por defecto'}
+            alt={value.alt || ''}
             src={imageUrl.url()}
             fill
+            sizes="(max-width: 768px) 100vw, 75vw"
+            className="object-contain"
           />
         </div>
       );

--- a/context/SanityContext.tsx
+++ b/context/SanityContext.tsx
@@ -9,7 +9,6 @@ import {
 // Define the expected structure of the context data
 export type SanityContextType = {
   pages: GetPagesNavQueryResult;
-  componentsMap: Record<string, string | null>[];
   unitBusinessList: GetUnitBusinessListQueryResult;
   settings: SettingsQueryResult;
 };

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,21 @@
+const remotePatterns = [
+  {
+    protocol: 'https',
+    hostname: 'cdn.sanity.io',
+    port: '',
+    pathname: '/**',
+  },
+];
+
+if (process.env.VIDEO_HERO_HOST) {
+  remotePatterns.push({
+    protocol: 'https',
+    hostname: process.env.VIDEO_HERO_HOST,
+    port: '',
+    pathname: '/**',
+  });
+}
+
 /** @type {import('next').NextConfig} */
 module.exports = {
   reactStrictMode: true,
@@ -9,22 +27,10 @@ module.exports = {
   logging: {
     fetches: { fullUrl: true },
   },
-  productionBrowserSourceMaps: true,
+  productionBrowserSourceMaps: false,
   images: {
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'cdn.sanity.io',
-        port: '',
-        pathname: '/**',
-      },
-      {
-        protocol: 'https',
-        hostname: process.env.VIDEO_HERO_HOST,
-        port: '',
-        pathname: '/**',
-      },
-    ],
+    formats: ['image/avif', 'image/webp'],
+    remotePatterns,
   },
   transpilePackages: ['lucide-react'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "embla-carousel-wheel-gestures": "^8.0.1",
         "framer-motion": "^12.4.0",
         "lucide-react": "^0.460.0",
-        "next": "^14.2.18",
+        "next": "14.2.35",
         "next-sanity": "^9.8.15",
         "postcss": "^8.4.49",
         "react": "^18.3.1",
@@ -60,7 +60,7 @@
       "devDependencies": {
         "@sanity/pkg-utils": "^6.11.11",
         "eslint": "^8.57.1",
-        "eslint-config-next": "^14.2.18",
+        "eslint-config-next": "14.2.35",
         "eslint-plugin-tailwindcss": "^3.17.5",
         "prettier": "^3.3.3",
         "prettier-plugin-tailwindcss": "^0.6.8"
@@ -3234,15 +3234,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.23.tgz",
-      "integrity": "sha512-CysUC9IO+2Bh0omJ3qrb47S8DtsTKbFidGm6ow4gXIG6reZybqxbkH2nhdEm1tC8SmgzDdpq3BIML0PWsmyUYA==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.23.tgz",
-      "integrity": "sha512-efRC7m39GoiU1fXZRgGySqYbQi6ZyLkuGlvGst7IwkTTczehQTJA/7PoMg4MMjUZvZEGpiSEu+oJBAjPawiC3Q==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.35.tgz",
+      "integrity": "sha512-Jw9A3ICz2183qSsqwi7fgq4SBPiNfmOLmTPXKvlnzstUwyvBrtySiY+8RXJweNAs9KThb1+bYhZh9XWcNOr2zQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3250,9 +3250,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.23.tgz",
-      "integrity": "sha512-WhtEntt6NcbABA8ypEoFd3uzq5iAnrl9AnZt9dXdO+PZLACE32z3a3qA5OoV20JrbJfSJ6Sd6EqGZTrlRnGxQQ==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
       "cpu": [
         "arm64"
       ],
@@ -3266,9 +3266,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.23.tgz",
-      "integrity": "sha512-vwLw0HN2gVclT/ikO6EcE+LcIN+0mddJ53yG4eZd0rXkuEr/RnOaMH8wg/sYl5iz5AYYRo/l6XX7FIo6kwbw1Q==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
       "cpu": [
         "x64"
       ],
@@ -3282,11 +3282,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.23.tgz",
-      "integrity": "sha512-uuAYwD3At2fu5CH1wD7FpP87mnjAv4+DNvLaR9kiIi8DLStWSW304kF09p1EQfhcbUI1Py2vZlBO2VaVqMRtpg==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3298,11 +3301,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.23.tgz",
-      "integrity": "sha512-Mm5KHd7nGgeJ4EETvVgFuqKOyDh+UMXHXxye6wRRFDr4FdVRI6YTxajoV2aHE8jqC14xeAMVZvLqYqS7isHL+g==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3314,11 +3320,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.23.tgz",
-      "integrity": "sha512-Ybfqlyzm4sMSEQO6lDksggAIxnvWSG2cDWnG2jgd+MLbHYn2pvFA8DQ4pT2Vjk3Cwrv+HIg7vXJ8lCiLz79qoQ==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3330,11 +3339,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.23.tgz",
-      "integrity": "sha512-OSQX94sxd1gOUz3jhhdocnKsy4/peG8zV1HVaW6DLEbEmRRtUCUQZcKxUD9atLYa3RZA+YJx+WZdOnTkDuNDNA==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3346,9 +3358,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.23.tgz",
-      "integrity": "sha512-ezmbgZy++XpIMTcTNd0L4k7+cNI4ET5vMv/oqNfTuSXkZtSA9BURElPFyarjjGtRgZ9/zuKDHoMdZwDZIY3ehQ==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
       "cpu": [
         "arm64"
       ],
@@ -3362,9 +3374,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.23.tgz",
-      "integrity": "sha512-zfHZOGguFCqAJ7zldTKg4tJHPJyJCOFhpoJcVxKL9BSUHScVDnMdDuOU1zPPGdOzr/GWxbhYTjyiEgLEpAoFPA==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
       "cpu": [
         "ia32"
       ],
@@ -3378,9 +3390,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.23.tgz",
-      "integrity": "sha512-xCtq5BD553SzOgSZ7UH5LH+OATQihydObTrCTvVzOro8QiWYKdBVwcB2Mn2MLMo6DGW9yH1LSPw7jS7HhgJgjw==",
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
       "cpu": [
         "x64"
       ],
@@ -9824,13 +9836,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.23.tgz",
-      "integrity": "sha512-qtWJzOsDZxnLtXLNtnVjbutHmnEp6QTTSZBTlTCge/Wy0AsUaq8nwR91dBcZZvFg3eY3zKFPBhUkLMHu3Qpauw==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.35.tgz",
+      "integrity": "sha512-BpLsv01UisH193WyT/1lpHqq5iJ/Orfz9h/NOOlAmTUq4GY349PextQ62K4XpnaM9supeiEn3TaOTeQO07gURg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "14.2.23",
+        "@next/eslint-plugin-next": "14.2.35",
         "@rushstack/eslint-patch": "^1.3.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -13875,12 +13887,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.23.tgz",
-      "integrity": "sha512-mjN3fE6u/tynneLiEg56XnthzuYw+kD7mCujgVqioxyPqbmiotUCGJpIZGS/VaPg3ZDT1tvWxiVyRzeqJFm/kw==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.23",
+        "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -13895,15 +13907,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.23",
-        "@next/swc-darwin-x64": "14.2.23",
-        "@next/swc-linux-arm64-gnu": "14.2.23",
-        "@next/swc-linux-arm64-musl": "14.2.23",
-        "@next/swc-linux-x64-gnu": "14.2.23",
-        "@next/swc-linux-x64-musl": "14.2.23",
-        "@next/swc-win32-arm64-msvc": "14.2.23",
-        "@next/swc-win32-ia32-msvc": "14.2.23",
-        "@next/swc-win32-x64-msvc": "14.2.23"
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "embla-carousel-wheel-gestures": "^8.0.1",
     "framer-motion": "^12.4.0",
     "lucide-react": "^0.460.0",
-    "next": "^14.2.18",
+    "next": "14.2.35",
     "next-sanity": "^9.8.15",
     "postcss": "^8.4.49",
     "react": "^18.3.1",
@@ -68,7 +68,7 @@
   "devDependencies": {
     "@sanity/pkg-utils": "^6.11.11",
     "eslint": "^8.57.1",
-    "eslint-config-next": "^14.2.18",
+    "eslint-config-next": "14.2.35",
     "eslint-plugin-tailwindcss": "^3.17.5",
     "prettier": "^3.3.3",
     "prettier-plugin-tailwindcss": "^0.6.8"

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -33,6 +33,10 @@ import background from './sanity/schemas/documents/background';
 import layer from './sanity/schemas/documents/layer';
 import colorItem from './sanity/schemas/documents/colorItem';
 import resourceItem from './sanity/schemas/documents/resourceItem';
+import seo from './sanity/schemas/objects/seo';
+
+const previewOrigin =
+  process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
 
 export default defineConfig({
   basePath: studioUrl,
@@ -57,6 +61,7 @@ export default defineConfig({
       service,
       unitBusiness,
       resourceItem,
+      seo,
     ],
   },
   plugins: [
@@ -80,7 +85,7 @@ export default defineConfig({
     presentationTool({
       resolve,
       previewUrl: {
-        origin: 'http://localhost:3000',
+        origin: previewOrigin,
         previewMode: {
           enable: '/api/draft',
           disable: '/api/disable',

--- a/sanity.types.ts
+++ b/sanity.types.ts
@@ -1757,7 +1757,7 @@ export type GetReactIconListQueryResult = Array<never>;
 
 // Source: ./sanity/lib/queries/page.query.ts
 // Variable: getPagesNavQuery
-// Query: *[_type == 'page' && isActive] | order(orderRank asc) {      "id": coalesce(_id, ""),       "name": coalesce(name, title),      title,      "slug": select(        isHome == true => "",        slug.current      ),      isHome,      orderRank,      isActive    }
+// Query: *[_type == 'page' && isActive == true && defined(slug.current)] | order(orderRank asc) {      "id": coalesce(_id, ""),       "name": coalesce(name, title),      title,      "slug": select(        isHome == true => "",        slug.current      ),      isHome,      orderRank,      isActive    }
 export type GetPagesNavQueryResult = Array<{
   id: string;
   name: string | null;
@@ -1768,13 +1768,14 @@ export type GetPagesNavQueryResult = Array<{
   isActive: boolean | null;
 }>;
 // Variable: getPageDetailQuery
-// Query: *[_type == 'page' && slug.current == $slug][0] {        "id": _id,    name,    "slug": slug.current,    isActive,    title,    content,    components[isActive]  {  // used as template for component in sanity  isActive,  typeComponent,  "typeComponentValue": typeComponent->value,  variant,  imageBackground,  'backgroundValue': background-> {  // used as template for background component in sanity  name,  backgroundMode,  imageBackgroundType,  colorWithDarkMode,  colorList,  "colors": colorList[]-> {    "lightColor": lightColor{      "rgb": rgb,      "alpha": alpha,      "hex": hex    },    "darkColor": darkColor{      "rgb": rgb,      "alpha": alpha,      "hex": hex    },    colorBackground1Position  },  directionDeg,  "layer" : backgroundLayer -> value,  responsiveHeight,  invertLayoutMobile,  invertLayoutDesk},  content,  ctaLinkBanner,  PTextBanner,  imageContent,  imagePosition,  videoUrl,  videoType,  layoutItems,  PTextItem,  resources,  items[isActive == true]  | order(orderRank asc) {    isActive,    image,    icon,    svgIcon,    svgIconList,    alt,    content,    ctaLinkItem,  } }    }
+// Query: *[_type == 'page' && isActive == true && slug.current == $slug][0] {        "id": _id,    name,    "slug": slug.current,    isActive,    title,    resumen,    content,      _updatedAt,  seo {    metaTitle,    metaDescription,    canonicalUrl,    noIndex,    ogImage  },    components[isActive == true] | order(orderRank asc) {  // used as template for component in sanity  _key,  isActive,  typeComponent,  "typeComponentValue": typeComponent->value,  variant,  imageBackground,  'backgroundValue': background-> {  // used as template for background component in sanity  name,  backgroundMode,  imageBackgroundType,  colorWithDarkMode,  colorList,  "colors": colorList[]-> {    "lightColor": lightColor{      "rgb": rgb,      "alpha": alpha,      "hex": hex    },    "darkColor": darkColor{      "rgb": rgb,      "alpha": alpha,      "hex": hex    },    colorBackground1Position  },  directionDeg,  "layer" : backgroundLayer -> value,  responsiveHeight,  invertLayoutMobile,  invertLayoutDesk},  content,  ctaLinkBanner,  PTextBanner,  imageContent,  imagePosition,  videoUrl,  videoType,  layoutItems,  PTextItem,  resources,  items[isActive == true]  | order(orderRank asc) {    _key,    isActive,    image,    icon,    svgIcon,    svgIconList,    "alt": coalesce(image.alt, alt),    content,    ctaLinkItem,  } }    }
 export type GetPageDetailQueryResult = {
   id: string;
   name: string | null;
   slug: string | null;
   isActive: boolean | null;
   title: string | null;
+  resumen: string | null;
   content: Array<
     | {
         children?: Array<{
@@ -1815,7 +1816,10 @@ export type GetPageDetailQueryResult = {
         _key: string;
       }
   > | null;
+  _updatedAt: string;
+  seo: null;
   components: Array<{
+    _key: string;
     isActive: boolean | null;
     typeComponent: {
       _ref: string;
@@ -1915,6 +1919,7 @@ export type GetPageDetailQueryResult = {
       } & ResourceItem
     > | null;
     items: Array<{
+      _key: string;
       isActive: boolean | null;
       image: {
         asset?: {
@@ -1982,10 +1987,11 @@ export type GetPageDetailQueryResult = {
 
 // Source: ./sanity/lib/queries/post.query.ts
 // Variable: getPostListQuery
-// Query: *[_type == 'post'] | order(orderRank desc) {        title,  slug,  "unitBusiness": {    "title": coalesce(unitBusiness->title, "Sin título"),    "icon": coalesce(unitBusiness->icon, "/default-icon.png"),    "slug": coalesce(unitBusiness->slug.current, "default-slug"),    "color": coalesce(unitBusiness->color, "bg-gray-100")  },  orderRank,  components[isActive] | order(orderRank asc) {  // used as template for component in sanity  isActive,  typeComponent,  "typeComponentValue": typeComponent->value,  variant,  imageBackground,  'backgroundValue': background-> {  // used as template for background component in sanity  name,  backgroundMode,  imageBackgroundType,  colorWithDarkMode,  colorList,  "colors": colorList[]-> {    "lightColor": lightColor{      "rgb": rgb,      "alpha": alpha,      "hex": hex    },    "darkColor": darkColor{      "rgb": rgb,      "alpha": alpha,      "hex": hex    },    colorBackground1Position  },  directionDeg,  "layer" : backgroundLayer -> value,  responsiveHeight,  invertLayoutMobile,  invertLayoutDesk},  content,  ctaLinkBanner,  PTextBanner,  imageContent,  imagePosition,  videoUrl,  videoType,  layoutItems,  PTextItem,  resources,  items[isActive == true]  | order(orderRank asc) {    isActive,    image,    icon,    svgIcon,    svgIconList,    alt,    content,    ctaLinkItem,  } },  "resumen": coalesce(    resumen,    array::join(content[_type == "block" && style == "normal"][0].children[].text, " ")  ),  date        }
+// Query: *[_type == 'post' && coalesce(isActive, true) == true && defined(slug.current)] | order(date desc, orderRank desc) {        _id,  title,  "slug": slug.current,  "unitBusiness": {    "title": coalesce(unitBusiness->title, "Sin título"),    "icon": coalesce(unitBusiness->icon, "/default-icon.png"),    "slug": coalesce(unitBusiness->slug.current, "default-slug"),    "color": coalesce(unitBusiness->color, "bg-gray-100")  },  orderRank,  "coverImage": coalesce(    coverImage,    components[isActive == true && typeComponent->value == "Heading"][0].imageBackground  ),  "resumen": coalesce(    resumen,    array::join(content[_type == "block" && style == "normal"][0].children[].text, " ")  ),  date,  _updatedAt        }
 export type GetPostListQueryResult = Array<{
+  _id: string;
   title: string | null;
-  slug: Slug | null;
+  slug: string | null;
   unitBusiness: {
     title: string | 'Sin t\xEDtulo';
     icon: '/default-icon.png' | 'menu' | 'user';
@@ -2001,177 +2007,27 @@ export type GetPostListQueryResult = Array<{
       | 'bg-yellow-100 text-yellow-800';
   };
   orderRank: string | null;
-  components: Array<{
-    isActive: boolean | null;
-    typeComponent: {
+  coverImage: {
+    asset?: {
       _ref: string;
       _type: 'reference';
       _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: 'component';
-    } | null;
-    typeComponentValue: string | null;
-    variant: 'hero' | 'post' | null;
-    imageBackground: {
-      asset?: {
-        _ref: string;
-        _type: 'reference';
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-      };
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: 'image';
-    } | null;
-    backgroundValue: {
-      name: string | null;
-      backgroundMode:
-        | 'colors'
-        | 'image'
-        | 'items'
-        | 'transparent'
-        | 'video'
-        | null;
-      imageBackgroundType: 'dynamic' | 'fixed' | null;
-      colorWithDarkMode: boolean | null;
-      colorList: Array<{
-        _ref: string;
-        _type: 'reference';
-        _weak?: boolean;
-        _key: string;
-        [internalGroqTypeReferenceTo]?: 'colorItem';
-      }> | null;
-      colors: Array<{
-        lightColor: {
-          rgb: RgbaColor | null;
-          alpha: number | null;
-          hex: string | null;
-        } | null;
-        darkColor: {
-          rgb: RgbaColor | null;
-          alpha: number | null;
-          hex: string | null;
-        } | null;
-        colorBackground1Position: number | null;
-      }> | null;
-      directionDeg: number | null;
-      layer: string | null;
-      responsiveHeight: 'fit-max' | 'h-900' | null;
-      invertLayoutMobile: boolean | null;
-      invertLayoutDesk: boolean | null;
-    } | null;
-    content: Array<{
-      children?: Array<{
-        marks?: Array<string>;
-        text?: string;
-        _type: 'span';
-        _key: string;
-      }>;
-      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal';
-      listItem?: 'bullet';
-      markDefs?: Array<{
-        href?: string;
-        _type: 'link';
-        _key: string;
-      }>;
-      level?: number;
-      _type: 'block';
-      _key: string;
-    }> | null;
-    ctaLinkBanner: string | null;
-    PTextBanner: string | null;
-    imageContent: {
-      asset?: {
-        _ref: string;
-        _type: 'reference';
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-      };
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: 'image';
-    } | null;
-    imagePosition: 'bottom' | 'left' | 'right' | 'top' | null;
-    videoUrl: string | null;
-    videoType: 'mp4' | 'webm' | null;
-    layoutItems: string | null;
-    PTextItem: string | null;
-    resources: Array<
-      {
-        _key: string;
-      } & ResourceItem
-    > | null;
-    items: Array<{
-      isActive: boolean | null;
-      image: {
-        asset?: {
-          _ref: string;
-          _type: 'reference';
-          _weak?: boolean;
-          [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-        };
-        hotspot?: SanityImageHotspot;
-        crop?: SanityImageCrop;
-        _type: 'image';
-      } | null;
-      icon: IconManager | null;
-      svgIcon: string | null;
-      svgIconList: Array<
-        {
-          _key: string;
-        } & IconsListItem
-      > | null;
-      alt: string | null;
-      content: Array<
-        | {
-            children?: Array<{
-              marks?: Array<string>;
-              text?: string;
-              _type: 'span';
-              _key: string;
-            }>;
-            style?:
-              | 'blockquote'
-              | 'h1'
-              | 'h2'
-              | 'h3'
-              | 'h4'
-              | 'h5'
-              | 'h6'
-              | 'normal';
-            listItem?: 'bullet' | 'number';
-            markDefs?: Array<{
-              href?: string;
-              _type: 'link';
-              _key: string;
-            }>;
-            level?: number;
-            _type: 'block';
-            _key: string;
-          }
-        | {
-            asset?: {
-              _ref: string;
-              _type: 'reference';
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-            };
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: 'image';
-            _key: string;
-          }
-      > | null;
-      ctaLinkItem: string | null;
-    }> | null;
-  }> | null;
+      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
+    };
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: 'image';
+  } | null;
   resumen: string | null;
   date: string | null;
+  _updatedAt: string;
 }>;
 // Variable: getPostListByUnitBusinessQuery
-// Query: *[_type == 'post' && unitBusiness->slug.current == $slug ] | order(orderRank desc){        title,  slug,  "unitBusiness": {    "title": coalesce(unitBusiness->title, "Sin título"),    "icon": coalesce(unitBusiness->icon, "/default-icon.png"),    "slug": coalesce(unitBusiness->slug.current, "default-slug"),    "color": coalesce(unitBusiness->color, "bg-gray-100")  },  orderRank,  components[isActive] | order(orderRank asc) {  // used as template for component in sanity  isActive,  typeComponent,  "typeComponentValue": typeComponent->value,  variant,  imageBackground,  'backgroundValue': background-> {  // used as template for background component in sanity  name,  backgroundMode,  imageBackgroundType,  colorWithDarkMode,  colorList,  "colors": colorList[]-> {    "lightColor": lightColor{      "rgb": rgb,      "alpha": alpha,      "hex": hex    },    "darkColor": darkColor{      "rgb": rgb,      "alpha": alpha,      "hex": hex    },    colorBackground1Position  },  directionDeg,  "layer" : backgroundLayer -> value,  responsiveHeight,  invertLayoutMobile,  invertLayoutDesk},  content,  ctaLinkBanner,  PTextBanner,  imageContent,  imagePosition,  videoUrl,  videoType,  layoutItems,  PTextItem,  resources,  items[isActive == true]  | order(orderRank asc) {    isActive,    image,    icon,    svgIcon,    svgIconList,    alt,    content,    ctaLinkItem,  } },  "resumen": coalesce(    resumen,    array::join(content[_type == "block" && style == "normal"][0].children[].text, " ")  ),  date        }
+// Query: *[_type == 'post' && coalesce(isActive, true) == true && defined(slug.current) && unitBusiness->slug.current == $slug] | order(date desc, orderRank desc) {        _id,  title,  "slug": slug.current,  "unitBusiness": {    "title": coalesce(unitBusiness->title, "Sin título"),    "icon": coalesce(unitBusiness->icon, "/default-icon.png"),    "slug": coalesce(unitBusiness->slug.current, "default-slug"),    "color": coalesce(unitBusiness->color, "bg-gray-100")  },  orderRank,  "coverImage": coalesce(    coverImage,    components[isActive == true && typeComponent->value == "Heading"][0].imageBackground  ),  "resumen": coalesce(    resumen,    array::join(content[_type == "block" && style == "normal"][0].children[].text, " ")  ),  date,  _updatedAt        }
 export type GetPostListByUnitBusinessQueryResult = Array<{
+  _id: string;
   title: string | null;
-  slug: Slug | null;
+  slug: string | null;
   unitBusiness: {
     title: string | 'Sin t\xEDtulo';
     icon: '/default-icon.png' | 'menu' | 'user';
@@ -2187,177 +2043,27 @@ export type GetPostListByUnitBusinessQueryResult = Array<{
       | 'bg-yellow-100 text-yellow-800';
   };
   orderRank: string | null;
-  components: Array<{
-    isActive: boolean | null;
-    typeComponent: {
+  coverImage: {
+    asset?: {
       _ref: string;
       _type: 'reference';
       _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: 'component';
-    } | null;
-    typeComponentValue: string | null;
-    variant: 'hero' | 'post' | null;
-    imageBackground: {
-      asset?: {
-        _ref: string;
-        _type: 'reference';
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-      };
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: 'image';
-    } | null;
-    backgroundValue: {
-      name: string | null;
-      backgroundMode:
-        | 'colors'
-        | 'image'
-        | 'items'
-        | 'transparent'
-        | 'video'
-        | null;
-      imageBackgroundType: 'dynamic' | 'fixed' | null;
-      colorWithDarkMode: boolean | null;
-      colorList: Array<{
-        _ref: string;
-        _type: 'reference';
-        _weak?: boolean;
-        _key: string;
-        [internalGroqTypeReferenceTo]?: 'colorItem';
-      }> | null;
-      colors: Array<{
-        lightColor: {
-          rgb: RgbaColor | null;
-          alpha: number | null;
-          hex: string | null;
-        } | null;
-        darkColor: {
-          rgb: RgbaColor | null;
-          alpha: number | null;
-          hex: string | null;
-        } | null;
-        colorBackground1Position: number | null;
-      }> | null;
-      directionDeg: number | null;
-      layer: string | null;
-      responsiveHeight: 'fit-max' | 'h-900' | null;
-      invertLayoutMobile: boolean | null;
-      invertLayoutDesk: boolean | null;
-    } | null;
-    content: Array<{
-      children?: Array<{
-        marks?: Array<string>;
-        text?: string;
-        _type: 'span';
-        _key: string;
-      }>;
-      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal';
-      listItem?: 'bullet';
-      markDefs?: Array<{
-        href?: string;
-        _type: 'link';
-        _key: string;
-      }>;
-      level?: number;
-      _type: 'block';
-      _key: string;
-    }> | null;
-    ctaLinkBanner: string | null;
-    PTextBanner: string | null;
-    imageContent: {
-      asset?: {
-        _ref: string;
-        _type: 'reference';
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-      };
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: 'image';
-    } | null;
-    imagePosition: 'bottom' | 'left' | 'right' | 'top' | null;
-    videoUrl: string | null;
-    videoType: 'mp4' | 'webm' | null;
-    layoutItems: string | null;
-    PTextItem: string | null;
-    resources: Array<
-      {
-        _key: string;
-      } & ResourceItem
-    > | null;
-    items: Array<{
-      isActive: boolean | null;
-      image: {
-        asset?: {
-          _ref: string;
-          _type: 'reference';
-          _weak?: boolean;
-          [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-        };
-        hotspot?: SanityImageHotspot;
-        crop?: SanityImageCrop;
-        _type: 'image';
-      } | null;
-      icon: IconManager | null;
-      svgIcon: string | null;
-      svgIconList: Array<
-        {
-          _key: string;
-        } & IconsListItem
-      > | null;
-      alt: string | null;
-      content: Array<
-        | {
-            children?: Array<{
-              marks?: Array<string>;
-              text?: string;
-              _type: 'span';
-              _key: string;
-            }>;
-            style?:
-              | 'blockquote'
-              | 'h1'
-              | 'h2'
-              | 'h3'
-              | 'h4'
-              | 'h5'
-              | 'h6'
-              | 'normal';
-            listItem?: 'bullet' | 'number';
-            markDefs?: Array<{
-              href?: string;
-              _type: 'link';
-              _key: string;
-            }>;
-            level?: number;
-            _type: 'block';
-            _key: string;
-          }
-        | {
-            asset?: {
-              _ref: string;
-              _type: 'reference';
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-            };
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: 'image';
-            _key: string;
-          }
-      > | null;
-      ctaLinkItem: string | null;
-    }> | null;
-  }> | null;
+      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
+    };
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: 'image';
+  } | null;
   resumen: string | null;
   date: string | null;
+  _updatedAt: string;
 }>;
 // Variable: getPostDetailQuery
-// Query: *[_type == 'post' && slug.current == $slug][0] {      title,  slug,  "unitBusiness": {    "title": coalesce(unitBusiness->title, "Sin título"),    "icon": coalesce(unitBusiness->icon, "/default-icon.png"),    "slug": coalesce(unitBusiness->slug.current, "default-slug"),    "color": coalesce(unitBusiness->color, "bg-gray-100")  },  orderRank,  components[isActive] | order(orderRank asc) {  // used as template for component in sanity  isActive,  typeComponent,  "typeComponentValue": typeComponent->value,  variant,  imageBackground,  'backgroundValue': background-> {  // used as template for background component in sanity  name,  backgroundMode,  imageBackgroundType,  colorWithDarkMode,  colorList,  "colors": colorList[]-> {    "lightColor": lightColor{      "rgb": rgb,      "alpha": alpha,      "hex": hex    },    "darkColor": darkColor{      "rgb": rgb,      "alpha": alpha,      "hex": hex    },    colorBackground1Position  },  directionDeg,  "layer" : backgroundLayer -> value,  responsiveHeight,  invertLayoutMobile,  invertLayoutDesk},  content,  ctaLinkBanner,  PTextBanner,  imageContent,  imagePosition,  videoUrl,  videoType,  layoutItems,  PTextItem,  resources,  items[isActive == true]  | order(orderRank asc) {    isActive,    image,    icon,    svgIcon,    svgIconList,    alt,    content,    ctaLinkItem,  } },  "resumen": coalesce(    resumen,    array::join(content[_type == "block" && style == "normal"][0].children[].text, " ")  ),  date  ,    content,    "tableOfContents" : content[style in ['h2', 'h3']] {      _key,      style,      'text':children[0].text     }  }
+// Query: *[_type == 'post' && coalesce(isActive, true) == true && slug.current == $slug][0] {        _id,  title,  "slug": slug.current,  "unitBusiness": {    "title": coalesce(unitBusiness->title, "Sin título"),    "icon": coalesce(unitBusiness->icon, "/default-icon.png"),    "slug": coalesce(unitBusiness->slug.current, "default-slug"),    "color": coalesce(unitBusiness->color, "bg-gray-100")  },  orderRank,  "coverImage": coalesce(    coverImage,    components[isActive == true && typeComponent->value == "Heading"][0].imageBackground  ),  "resumen": coalesce(    resumen,    array::join(content[_type == "block" && style == "normal"][0].children[].text, " ")  ),  date,  _updatedAt  ,  content,    _updatedAt,  seo {    metaTitle,    metaDescription,    canonicalUrl,    noIndex,    ogImage  },  "author": author->{name, role, credentials, bio, picture},  components[isActive == true] | order(orderRank asc) {  // used as template for component in sanity  _key,  isActive,  typeComponent,  "typeComponentValue": typeComponent->value,  variant,  imageBackground,  'backgroundValue': background-> {  // used as template for background component in sanity  name,  backgroundMode,  imageBackgroundType,  colorWithDarkMode,  colorList,  "colors": colorList[]-> {    "lightColor": lightColor{      "rgb": rgb,      "alpha": alpha,      "hex": hex    },    "darkColor": darkColor{      "rgb": rgb,      "alpha": alpha,      "hex": hex    },    colorBackground1Position  },  directionDeg,  "layer" : backgroundLayer -> value,  responsiveHeight,  invertLayoutMobile,  invertLayoutDesk},  content,  ctaLinkBanner,  PTextBanner,  imageContent,  imagePosition,  videoUrl,  videoType,  layoutItems,  PTextItem,  resources,  items[isActive == true]  | order(orderRank asc) {    _key,    isActive,    image,    icon,    svgIcon,    svgIconList,    "alt": coalesce(image.alt, alt),    content,    ctaLinkItem,  } },    "tableOfContents" : content[style in ['h2', 'h3']] {      _key,      style,      'text':children[0].text     }  }
 export type GetPostDetailQueryResult = {
+  _id: string;
   title: string | null;
-  slug: Slug | null;
+  slug: string | null;
   unitBusiness: {
     title: string | 'Sin t\xEDtulo';
     icon: '/default-icon.png' | 'menu' | 'user';
@@ -2373,171 +2079,20 @@ export type GetPostDetailQueryResult = {
       | 'bg-yellow-100 text-yellow-800';
   };
   orderRank: string | null;
-  components: Array<{
-    isActive: boolean | null;
-    typeComponent: {
+  coverImage: {
+    asset?: {
       _ref: string;
       _type: 'reference';
       _weak?: boolean;
-      [internalGroqTypeReferenceTo]?: 'component';
-    } | null;
-    typeComponentValue: string | null;
-    variant: 'hero' | 'post' | null;
-    imageBackground: {
-      asset?: {
-        _ref: string;
-        _type: 'reference';
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-      };
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: 'image';
-    } | null;
-    backgroundValue: {
-      name: string | null;
-      backgroundMode:
-        | 'colors'
-        | 'image'
-        | 'items'
-        | 'transparent'
-        | 'video'
-        | null;
-      imageBackgroundType: 'dynamic' | 'fixed' | null;
-      colorWithDarkMode: boolean | null;
-      colorList: Array<{
-        _ref: string;
-        _type: 'reference';
-        _weak?: boolean;
-        _key: string;
-        [internalGroqTypeReferenceTo]?: 'colorItem';
-      }> | null;
-      colors: Array<{
-        lightColor: {
-          rgb: RgbaColor | null;
-          alpha: number | null;
-          hex: string | null;
-        } | null;
-        darkColor: {
-          rgb: RgbaColor | null;
-          alpha: number | null;
-          hex: string | null;
-        } | null;
-        colorBackground1Position: number | null;
-      }> | null;
-      directionDeg: number | null;
-      layer: string | null;
-      responsiveHeight: 'fit-max' | 'h-900' | null;
-      invertLayoutMobile: boolean | null;
-      invertLayoutDesk: boolean | null;
-    } | null;
-    content: Array<{
-      children?: Array<{
-        marks?: Array<string>;
-        text?: string;
-        _type: 'span';
-        _key: string;
-      }>;
-      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal';
-      listItem?: 'bullet';
-      markDefs?: Array<{
-        href?: string;
-        _type: 'link';
-        _key: string;
-      }>;
-      level?: number;
-      _type: 'block';
-      _key: string;
-    }> | null;
-    ctaLinkBanner: string | null;
-    PTextBanner: string | null;
-    imageContent: {
-      asset?: {
-        _ref: string;
-        _type: 'reference';
-        _weak?: boolean;
-        [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-      };
-      hotspot?: SanityImageHotspot;
-      crop?: SanityImageCrop;
-      _type: 'image';
-    } | null;
-    imagePosition: 'bottom' | 'left' | 'right' | 'top' | null;
-    videoUrl: string | null;
-    videoType: 'mp4' | 'webm' | null;
-    layoutItems: string | null;
-    PTextItem: string | null;
-    resources: Array<
-      {
-        _key: string;
-      } & ResourceItem
-    > | null;
-    items: Array<{
-      isActive: boolean | null;
-      image: {
-        asset?: {
-          _ref: string;
-          _type: 'reference';
-          _weak?: boolean;
-          [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-        };
-        hotspot?: SanityImageHotspot;
-        crop?: SanityImageCrop;
-        _type: 'image';
-      } | null;
-      icon: IconManager | null;
-      svgIcon: string | null;
-      svgIconList: Array<
-        {
-          _key: string;
-        } & IconsListItem
-      > | null;
-      alt: string | null;
-      content: Array<
-        | {
-            children?: Array<{
-              marks?: Array<string>;
-              text?: string;
-              _type: 'span';
-              _key: string;
-            }>;
-            style?:
-              | 'blockquote'
-              | 'h1'
-              | 'h2'
-              | 'h3'
-              | 'h4'
-              | 'h5'
-              | 'h6'
-              | 'normal';
-            listItem?: 'bullet' | 'number';
-            markDefs?: Array<{
-              href?: string;
-              _type: 'link';
-              _key: string;
-            }>;
-            level?: number;
-            _type: 'block';
-            _key: string;
-          }
-        | {
-            asset?: {
-              _ref: string;
-              _type: 'reference';
-              _weak?: boolean;
-              [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-            };
-            hotspot?: SanityImageHotspot;
-            crop?: SanityImageCrop;
-            _type: 'image';
-            _key: string;
-          }
-      > | null;
-      ctaLinkItem: string | null;
-    }> | null;
-  }> | null;
+      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
+    };
+    hotspot?: SanityImageHotspot;
+    crop?: SanityImageCrop;
+    _type: 'image';
+  } | null;
   resumen: string | null;
   date: string | null;
+  _updatedAt: string;
   content: Array<
     | {
         children?: Array<{
@@ -2570,6 +2125,173 @@ export type GetPostDetailQueryResult = {
         _key: string;
       }
   > | null;
+  seo: null;
+  author: null;
+  components: Array<{
+    _key: string;
+    isActive: boolean | null;
+    typeComponent: {
+      _ref: string;
+      _type: 'reference';
+      _weak?: boolean;
+      [internalGroqTypeReferenceTo]?: 'component';
+    } | null;
+    typeComponentValue: string | null;
+    variant: 'hero' | 'post' | null;
+    imageBackground: {
+      asset?: {
+        _ref: string;
+        _type: 'reference';
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
+      };
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: 'image';
+    } | null;
+    backgroundValue: {
+      name: string | null;
+      backgroundMode:
+        | 'colors'
+        | 'image'
+        | 'items'
+        | 'transparent'
+        | 'video'
+        | null;
+      imageBackgroundType: 'dynamic' | 'fixed' | null;
+      colorWithDarkMode: boolean | null;
+      colorList: Array<{
+        _ref: string;
+        _type: 'reference';
+        _weak?: boolean;
+        _key: string;
+        [internalGroqTypeReferenceTo]?: 'colorItem';
+      }> | null;
+      colors: Array<{
+        lightColor: {
+          rgb: RgbaColor | null;
+          alpha: number | null;
+          hex: string | null;
+        } | null;
+        darkColor: {
+          rgb: RgbaColor | null;
+          alpha: number | null;
+          hex: string | null;
+        } | null;
+        colorBackground1Position: number | null;
+      }> | null;
+      directionDeg: number | null;
+      layer: string | null;
+      responsiveHeight: 'fit-max' | 'h-900' | null;
+      invertLayoutMobile: boolean | null;
+      invertLayoutDesk: boolean | null;
+    } | null;
+    content: Array<{
+      children?: Array<{
+        marks?: Array<string>;
+        text?: string;
+        _type: 'span';
+        _key: string;
+      }>;
+      style?: 'blockquote' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'normal';
+      listItem?: 'bullet';
+      markDefs?: Array<{
+        href?: string;
+        _type: 'link';
+        _key: string;
+      }>;
+      level?: number;
+      _type: 'block';
+      _key: string;
+    }> | null;
+    ctaLinkBanner: string | null;
+    PTextBanner: string | null;
+    imageContent: {
+      asset?: {
+        _ref: string;
+        _type: 'reference';
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
+      };
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: 'image';
+    } | null;
+    imagePosition: 'bottom' | 'left' | 'right' | 'top' | null;
+    videoUrl: string | null;
+    videoType: 'mp4' | 'webm' | null;
+    layoutItems: string | null;
+    PTextItem: string | null;
+    resources: Array<
+      {
+        _key: string;
+      } & ResourceItem
+    > | null;
+    items: Array<{
+      _key: string;
+      isActive: boolean | null;
+      image: {
+        asset?: {
+          _ref: string;
+          _type: 'reference';
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
+        };
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        _type: 'image';
+      } | null;
+      icon: IconManager | null;
+      svgIcon: string | null;
+      svgIconList: Array<
+        {
+          _key: string;
+        } & IconsListItem
+      > | null;
+      alt: string | null;
+      content: Array<
+        | {
+            children?: Array<{
+              marks?: Array<string>;
+              text?: string;
+              _type: 'span';
+              _key: string;
+            }>;
+            style?:
+              | 'blockquote'
+              | 'h1'
+              | 'h2'
+              | 'h3'
+              | 'h4'
+              | 'h5'
+              | 'h6'
+              | 'normal';
+            listItem?: 'bullet' | 'number';
+            markDefs?: Array<{
+              href?: string;
+              _type: 'link';
+              _key: string;
+            }>;
+            level?: number;
+            _type: 'block';
+            _key: string;
+          }
+        | {
+            asset?: {
+              _ref: string;
+              _type: 'reference';
+              _weak?: boolean;
+              [internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
+            };
+            hotspot?: SanityImageHotspot;
+            crop?: SanityImageCrop;
+            _type: 'image';
+            _key: string;
+          }
+      > | null;
+      ctaLinkItem: string | null;
+    }> | null;
+  }> | null;
   tableOfContents: Array<{
     _key: string;
     style: 'blockquote' | 'h2' | 'h3' | 'normal' | null;
@@ -2600,11 +2322,14 @@ export type GetServicesNavQueryResult = Array<{
   };
 }>;
 // Variable: getServiceDetailQuery
-// Query: *[_type == 'service' && slug.current == $slug][0] {    title,  // Fetch the title of the service    iconfyIcon,    resumen,    content,  // Fetch the content of the service    "tableOfContents" : content[style in ['h2']] {      _key,      style,      'text':children[0].text     },    "unitBusiness": {    "title": coalesce(unitBusiness->title, "Sin título"),    "icon": coalesce(unitBusiness->icon, "/default-icon.png"),    "slug": coalesce(unitBusiness->slug.current, "default-slug"),    "color": coalesce(unitBusiness->color, "bg-gray-100")  },    components[isActive] {  // used as template for component in sanity  isActive,  typeComponent,  "typeComponentValue": typeComponent->value,  variant,  imageBackground,  'backgroundValue': background-> {  // used as template for background component in sanity  name,  backgroundMode,  imageBackgroundType,  colorWithDarkMode,  colorList,  "colors": colorList[]-> {    "lightColor": lightColor{      "rgb": rgb,      "alpha": alpha,      "hex": hex    },    "darkColor": darkColor{      "rgb": rgb,      "alpha": alpha,      "hex": hex    },    colorBackground1Position  },  directionDeg,  "layer" : backgroundLayer -> value,  responsiveHeight,  invertLayoutMobile,  invertLayoutDesk},  content,  ctaLinkBanner,  PTextBanner,  imageContent,  imagePosition,  videoUrl,  videoType,  layoutItems,  PTextItem,  resources,  items[isActive == true]  | order(orderRank asc) {    isActive,    image,    icon,    svgIcon,    svgIconList,    alt,    content,    ctaLinkItem,  } }  }
+// Query: *[_type == 'service' && isActive == true && slug.current == $slug][0] {    title,  // Fetch the title of the service    "slug": slug.current,    iconfyIcon,    resumen,      _updatedAt,  seo {    metaTitle,    metaDescription,    canonicalUrl,    noIndex,    ogImage  },    content,  // Fetch the content of the service    "tableOfContents" : content[style in ['h2']] {      _key,      style,      'text':children[0].text     },    "unitBusiness": {    "title": coalesce(unitBusiness->title, "Sin título"),    "icon": coalesce(unitBusiness->icon, "/default-icon.png"),    "slug": coalesce(unitBusiness->slug.current, "default-slug"),    "color": coalesce(unitBusiness->color, "bg-gray-100")  },    components[isActive == true] | order(orderRank asc) {  // used as template for component in sanity  _key,  isActive,  typeComponent,  "typeComponentValue": typeComponent->value,  variant,  imageBackground,  'backgroundValue': background-> {  // used as template for background component in sanity  name,  backgroundMode,  imageBackgroundType,  colorWithDarkMode,  colorList,  "colors": colorList[]-> {    "lightColor": lightColor{      "rgb": rgb,      "alpha": alpha,      "hex": hex    },    "darkColor": darkColor{      "rgb": rgb,      "alpha": alpha,      "hex": hex    },    colorBackground1Position  },  directionDeg,  "layer" : backgroundLayer -> value,  responsiveHeight,  invertLayoutMobile,  invertLayoutDesk},  content,  ctaLinkBanner,  PTextBanner,  imageContent,  imagePosition,  videoUrl,  videoType,  layoutItems,  PTextItem,  resources,  items[isActive == true]  | order(orderRank asc) {    _key,    isActive,    image,    icon,    svgIcon,    svgIconList,    "alt": coalesce(image.alt, alt),    content,    ctaLinkItem,  } }  }
 export type GetServiceDetailQueryResult = {
   title: string | null;
+  slug: string | null;
   iconfyIcon: IconManager | null;
   resumen: string | null;
+  _updatedAt: string;
+  seo: null;
   content: Array<
     | {
         children?: Array<{
@@ -2674,6 +2399,7 @@ export type GetServiceDetailQueryResult = {
       | 'bg-yellow-100 text-yellow-800';
   };
   components: Array<{
+    _key: string;
     isActive: boolean | null;
     typeComponent: {
       _ref: string;
@@ -2773,6 +2499,7 @@ export type GetServiceDetailQueryResult = {
       } & ResourceItem
     > | null;
     items: Array<{
+      _key: string;
       isActive: boolean | null;
       image: {
         asset?: {
@@ -2838,9 +2565,32 @@ export type GetServiceDetailQueryResult = {
   }> | null;
 } | null;
 
+// Source: ./sanity/lib/queries/sitemap.query.ts
+// Variable: sitemapQuery
+// Query: {  "pages": *[    _type == "page" &&    isActive == true &&    defined(slug.current) &&    coalesce(seo.noIndex, false) == false  ] {    "slug": slug.current,    isHome,    _updatedAt  },  "posts": *[    _type == "post" &&    coalesce(isActive, true) == true &&    defined(slug.current) &&    coalesce(seo.noIndex, false) == false  ] {    "slug": slug.current,    _updatedAt  },  "services": *[    _type == "service" &&    isActive == true &&    defined(slug.current) &&    coalesce(seo.noIndex, false) == false  ] {    "slug": slug.current,    _updatedAt  },  "unitBusiness": *[    _type == "unitBusiness" &&    coalesce(isActive, true) == true &&    defined(slug.current) &&    coalesce(seo.noIndex, false) == false  ] {    "slug": slug.current,    _updatedAt  }}
+export type SitemapQueryResult = {
+  pages: Array<{
+    slug: string | null;
+    isHome: boolean | null;
+    _updatedAt: string;
+  }>;
+  posts: Array<{
+    slug: string | null;
+    _updatedAt: string;
+  }>;
+  services: Array<{
+    slug: string | null;
+    _updatedAt: string;
+  }>;
+  unitBusiness: Array<{
+    slug: string | null;
+    _updatedAt: string;
+  }>;
+};
+
 // Source: ./sanity/lib/queries/unitBusiness.query.ts
 // Variable: getUnitBusinessListQuery
-// Query: *[_type == 'unitBusiness'] |  order(orderRank asc) {      title,      "slug": slug.current,      color,      "services" : services[] -> {        title,        "slug": slug.current,      },        orderRank,  }
+// Query: *[_type == 'unitBusiness' && coalesce(isActive, true) == true && defined(slug.current)] | order(orderRank asc) {      title,      "slug": slug.current,      color,      "services" : services[] -> {        title,        "slug": slug.current,      },        orderRank,  }
 export type GetUnitBusinessListQueryResult = Array<{
   title: string | null;
   slug: string | null;
@@ -2860,7 +2610,7 @@ export type GetUnitBusinessListQueryResult = Array<{
   orderRank: string | null;
 }>;
 // Variable: getUnitBusinessDetailQuery
-// Query: *[_type == 'unitBusiness' && slug.current == $slug][0] {        "id": _id,  title,  "slug": slug.current,  icon,  color,  description,  "services" : services[] -> {    title,    "slug": slug.current,    iconfyIcon,    resumen,    },  components[isActive] {  // used as template for component in sanity  isActive,  typeComponent,  "typeComponentValue": typeComponent->value,  variant,  imageBackground,  'backgroundValue': background-> {  // used as template for background component in sanity  name,  backgroundMode,  imageBackgroundType,  colorWithDarkMode,  colorList,  "colors": colorList[]-> {    "lightColor": lightColor{      "rgb": rgb,      "alpha": alpha,      "hex": hex    },    "darkColor": darkColor{      "rgb": rgb,      "alpha": alpha,      "hex": hex    },    colorBackground1Position  },  directionDeg,  "layer" : backgroundLayer -> value,  responsiveHeight,  invertLayoutMobile,  invertLayoutDesk},  content,  ctaLinkBanner,  PTextBanner,  imageContent,  imagePosition,  videoUrl,  videoType,  layoutItems,  PTextItem,  resources,  items[isActive == true]  | order(orderRank asc) {    isActive,    image,    icon,    svgIcon,    svgIconList,    alt,    content,    ctaLinkItem,  } }    }
+// Query: *[_type == 'unitBusiness' && coalesce(isActive, true) == true && slug.current == $slug][0] {        "id": _id,  title,  "slug": slug.current,  icon,  color,  description,    _updatedAt,  seo {    metaTitle,    metaDescription,    canonicalUrl,    noIndex,    ogImage  },  "services" : services[] -> {    title,    "slug": slug.current,    iconfyIcon,    resumen,    },  components[isActive == true] | order(orderRank asc) {  // used as template for component in sanity  _key,  isActive,  typeComponent,  "typeComponentValue": typeComponent->value,  variant,  imageBackground,  'backgroundValue': background-> {  // used as template for background component in sanity  name,  backgroundMode,  imageBackgroundType,  colorWithDarkMode,  colorList,  "colors": colorList[]-> {    "lightColor": lightColor{      "rgb": rgb,      "alpha": alpha,      "hex": hex    },    "darkColor": darkColor{      "rgb": rgb,      "alpha": alpha,      "hex": hex    },    colorBackground1Position  },  directionDeg,  "layer" : backgroundLayer -> value,  responsiveHeight,  invertLayoutMobile,  invertLayoutDesk},  content,  ctaLinkBanner,  PTextBanner,  imageContent,  imagePosition,  videoUrl,  videoType,  layoutItems,  PTextItem,  resources,  items[isActive == true]  | order(orderRank asc) {    _key,    isActive,    image,    icon,    svgIcon,    svgIconList,    "alt": coalesce(image.alt, alt),    content,    ctaLinkItem,  } }    }
 export type GetUnitBusinessDetailQueryResult = {
   id: string;
   title: string | null;
@@ -2915,6 +2665,8 @@ export type GetUnitBusinessDetailQueryResult = {
         _key: string;
       }
   > | null;
+  _updatedAt: string;
+  seo: null;
   services: Array<{
     title: string | null;
     slug: string | null;
@@ -2922,6 +2674,7 @@ export type GetUnitBusinessDetailQueryResult = {
     resumen: string | null;
   }> | null;
   components: Array<{
+    _key: string;
     isActive: boolean | null;
     typeComponent: {
       _ref: string;
@@ -3021,6 +2774,7 @@ export type GetUnitBusinessDetailQueryResult = {
       } & ResourceItem
     > | null;
     items: Array<{
+      _key: string;
       isActive: boolean | null;
       image: {
         asset?: {
@@ -3097,14 +2851,15 @@ declare module '@sanity/client' {
     "*[_type == 'component']{\n  value, name\n}": GetComponentListQueryResult;
     "*[_type == 'icon']{\n  value, name\n}": GetIconListQueryResult;
     "*[_type == 'reactIcon']{\n  iconGroup, iconName\n}": GetReactIconListQueryResult;
-    '\n    *[_type == \'page\' && isActive] | order(orderRank asc) {\n      "id": coalesce(_id, ""), \n      "name": coalesce(name, title),\n      title,\n      "slug": select(\n        isHome == true => "",\n        slug.current\n      ),\n      isHome,\n      orderRank,\n      isActive\n    }\n  ': GetPagesNavQueryResult;
-    '\n    *[_type == \'page\' && slug.current == $slug][0] {\n    \n    "id": _id,\n    name,\n    "slug": slug.current,\n    isActive,\n    title,\n    content,\n    components[isActive]  {  // used as template for component in sanity\n  isActive,\n  typeComponent,\n  "typeComponentValue": typeComponent->value,\n  variant,\n  imageBackground,\n  \'backgroundValue\': background-> {  // used as template for background component in sanity\n  name,\n  backgroundMode,\n  imageBackgroundType,\n  colorWithDarkMode,\n  colorList,\n  "colors": colorList[]-> {\n    "lightColor": lightColor{\n      "rgb": rgb,\n      "alpha": alpha,\n      "hex": hex\n    },\n    "darkColor": darkColor{\n      "rgb": rgb,\n      "alpha": alpha,\n      "hex": hex\n    },\n    colorBackground1Position\n  },\n  directionDeg,\n  "layer" : backgroundLayer -> value,\n  responsiveHeight,\n  invertLayoutMobile,\n  invertLayoutDesk\n},\n  content,\n  ctaLinkBanner,\n  PTextBanner,\n  imageContent,\n  imagePosition,\n  videoUrl,\n  videoType,\n  layoutItems,\n  PTextItem,\n  resources,\n  items[isActive == true]  | order(orderRank asc) {\n    isActive,\n    image,\n    icon,\n    svgIcon,\n    svgIconList,\n    alt,\n    content,\n    ctaLinkItem,\n  }\n }\n\n    }': GetPageDetailQueryResult;
-    '\n    *[_type == \'post\'] | order(orderRank desc) {\n      \n  title,\n  slug,\n  \n"unitBusiness": {\n    "title": coalesce(unitBusiness->title, "Sin t\xEDtulo"),\n    "icon": coalesce(unitBusiness->icon, "/default-icon.png"),\n    "slug": coalesce(unitBusiness->slug.current, "default-slug"),\n    "color": coalesce(unitBusiness->color, "bg-gray-100")\n  }\n,\n  orderRank,\n  components[isActive] | order(orderRank asc) {  // used as template for component in sanity\n  isActive,\n  typeComponent,\n  "typeComponentValue": typeComponent->value,\n  variant,\n  imageBackground,\n  \'backgroundValue\': background-> {  // used as template for background component in sanity\n  name,\n  backgroundMode,\n  imageBackgroundType,\n  colorWithDarkMode,\n  colorList,\n  "colors": colorList[]-> {\n    "lightColor": lightColor{\n      "rgb": rgb,\n      "alpha": alpha,\n      "hex": hex\n    },\n    "darkColor": darkColor{\n      "rgb": rgb,\n      "alpha": alpha,\n      "hex": hex\n    },\n    colorBackground1Position\n  },\n  directionDeg,\n  "layer" : backgroundLayer -> value,\n  responsiveHeight,\n  invertLayoutMobile,\n  invertLayoutDesk\n},\n  content,\n  ctaLinkBanner,\n  PTextBanner,\n  imageContent,\n  imagePosition,\n  videoUrl,\n  videoType,\n  layoutItems,\n  PTextItem,\n  resources,\n  items[isActive == true]  | order(orderRank asc) {\n    isActive,\n    image,\n    icon,\n    svgIcon,\n    svgIconList,\n    alt,\n    content,\n    ctaLinkItem,\n  }\n },\n  "resumen": coalesce(\n    resumen,\n    array::join(content[_type == "block" && style == "normal"][0].children[].text, " ")\n  ),\n  date\n  \n      }': GetPostListQueryResult;
-    '\n    *[_type == \'post\' && unitBusiness->slug.current == $slug ] | order(orderRank desc){\n      \n  title,\n  slug,\n  \n"unitBusiness": {\n    "title": coalesce(unitBusiness->title, "Sin t\xEDtulo"),\n    "icon": coalesce(unitBusiness->icon, "/default-icon.png"),\n    "slug": coalesce(unitBusiness->slug.current, "default-slug"),\n    "color": coalesce(unitBusiness->color, "bg-gray-100")\n  }\n,\n  orderRank,\n  components[isActive] | order(orderRank asc) {  // used as template for component in sanity\n  isActive,\n  typeComponent,\n  "typeComponentValue": typeComponent->value,\n  variant,\n  imageBackground,\n  \'backgroundValue\': background-> {  // used as template for background component in sanity\n  name,\n  backgroundMode,\n  imageBackgroundType,\n  colorWithDarkMode,\n  colorList,\n  "colors": colorList[]-> {\n    "lightColor": lightColor{\n      "rgb": rgb,\n      "alpha": alpha,\n      "hex": hex\n    },\n    "darkColor": darkColor{\n      "rgb": rgb,\n      "alpha": alpha,\n      "hex": hex\n    },\n    colorBackground1Position\n  },\n  directionDeg,\n  "layer" : backgroundLayer -> value,\n  responsiveHeight,\n  invertLayoutMobile,\n  invertLayoutDesk\n},\n  content,\n  ctaLinkBanner,\n  PTextBanner,\n  imageContent,\n  imagePosition,\n  videoUrl,\n  videoType,\n  layoutItems,\n  PTextItem,\n  resources,\n  items[isActive == true]  | order(orderRank asc) {\n    isActive,\n    image,\n    icon,\n    svgIcon,\n    svgIconList,\n    alt,\n    content,\n    ctaLinkItem,\n  }\n },\n  "resumen": coalesce(\n    resumen,\n    array::join(content[_type == "block" && style == "normal"][0].children[].text, " ")\n  ),\n  date\n  \n      }': GetPostListByUnitBusinessQueryResult;
-    '\n  *[_type == \'post\' && slug.current == $slug][0] {\n    \n  title,\n  slug,\n  \n"unitBusiness": {\n    "title": coalesce(unitBusiness->title, "Sin t\xEDtulo"),\n    "icon": coalesce(unitBusiness->icon, "/default-icon.png"),\n    "slug": coalesce(unitBusiness->slug.current, "default-slug"),\n    "color": coalesce(unitBusiness->color, "bg-gray-100")\n  }\n,\n  orderRank,\n  components[isActive] | order(orderRank asc) {  // used as template for component in sanity\n  isActive,\n  typeComponent,\n  "typeComponentValue": typeComponent->value,\n  variant,\n  imageBackground,\n  \'backgroundValue\': background-> {  // used as template for background component in sanity\n  name,\n  backgroundMode,\n  imageBackgroundType,\n  colorWithDarkMode,\n  colorList,\n  "colors": colorList[]-> {\n    "lightColor": lightColor{\n      "rgb": rgb,\n      "alpha": alpha,\n      "hex": hex\n    },\n    "darkColor": darkColor{\n      "rgb": rgb,\n      "alpha": alpha,\n      "hex": hex\n    },\n    colorBackground1Position\n  },\n  directionDeg,\n  "layer" : backgroundLayer -> value,\n  responsiveHeight,\n  invertLayoutMobile,\n  invertLayoutDesk\n},\n  content,\n  ctaLinkBanner,\n  PTextBanner,\n  imageContent,\n  imagePosition,\n  videoUrl,\n  videoType,\n  layoutItems,\n  PTextItem,\n  resources,\n  items[isActive == true]  | order(orderRank asc) {\n    isActive,\n    image,\n    icon,\n    svgIcon,\n    svgIconList,\n    alt,\n    content,\n    ctaLinkItem,\n  }\n },\n  "resumen": coalesce(\n    resumen,\n    array::join(content[_type == "block" && style == "normal"][0].children[].text, " ")\n  ),\n  date\n  ,\n    content,\n    "tableOfContents" : content[style in [\'h2\', \'h3\']] {\n      _key,\n      style,\n      \'text\':children[0].text \n    }\n  }\n': GetPostDetailQueryResult;
+    '\n    *[_type == \'page\' && isActive == true && defined(slug.current)] | order(orderRank asc) {\n      "id": coalesce(_id, ""), \n      "name": coalesce(name, title),\n      title,\n      "slug": select(\n        isHome == true => "",\n        slug.current\n      ),\n      isHome,\n      orderRank,\n      isActive\n    }\n  ': GetPagesNavQueryResult;
+    '\n    *[_type == \'page\' && isActive == true && slug.current == $slug][0] {\n    \n    "id": _id,\n    name,\n    "slug": slug.current,\n    isActive,\n    title,\n    resumen,\n    content,\n    \n  _updatedAt,\n  seo {\n    metaTitle,\n    metaDescription,\n    canonicalUrl,\n    noIndex,\n    ogImage\n  }\n,\n    components[isActive == true] | order(orderRank asc) {  // used as template for component in sanity\n  _key,\n  isActive,\n  typeComponent,\n  "typeComponentValue": typeComponent->value,\n  variant,\n  imageBackground,\n  \'backgroundValue\': background-> {  // used as template for background component in sanity\n  name,\n  backgroundMode,\n  imageBackgroundType,\n  colorWithDarkMode,\n  colorList,\n  "colors": colorList[]-> {\n    "lightColor": lightColor{\n      "rgb": rgb,\n      "alpha": alpha,\n      "hex": hex\n    },\n    "darkColor": darkColor{\n      "rgb": rgb,\n      "alpha": alpha,\n      "hex": hex\n    },\n    colorBackground1Position\n  },\n  directionDeg,\n  "layer" : backgroundLayer -> value,\n  responsiveHeight,\n  invertLayoutMobile,\n  invertLayoutDesk\n},\n  content,\n  ctaLinkBanner,\n  PTextBanner,\n  imageContent,\n  imagePosition,\n  videoUrl,\n  videoType,\n  layoutItems,\n  PTextItem,\n  resources,\n  items[isActive == true]  | order(orderRank asc) {\n    _key,\n    isActive,\n    image,\n    icon,\n    svgIcon,\n    svgIconList,\n    "alt": coalesce(image.alt, alt),\n    content,\n    ctaLinkItem,\n  }\n }\n\n    }': GetPageDetailQueryResult;
+    '\n    *[_type == \'post\' && coalesce(isActive, true) == true && defined(slug.current)] | order(date desc, orderRank desc) {\n      \n  _id,\n  title,\n  "slug": slug.current,\n  \n"unitBusiness": {\n    "title": coalesce(unitBusiness->title, "Sin t\xEDtulo"),\n    "icon": coalesce(unitBusiness->icon, "/default-icon.png"),\n    "slug": coalesce(unitBusiness->slug.current, "default-slug"),\n    "color": coalesce(unitBusiness->color, "bg-gray-100")\n  }\n,\n  orderRank,\n  "coverImage": coalesce(\n    coverImage,\n    components[isActive == true && typeComponent->value == "Heading"][0].imageBackground\n  ),\n  "resumen": coalesce(\n    resumen,\n    array::join(content[_type == "block" && style == "normal"][0].children[].text, " ")\n  ),\n  date,\n  _updatedAt\n  \n      }': GetPostListQueryResult;
+    '\n    *[_type == \'post\' && coalesce(isActive, true) == true && defined(slug.current) && unitBusiness->slug.current == $slug] | order(date desc, orderRank desc) {\n      \n  _id,\n  title,\n  "slug": slug.current,\n  \n"unitBusiness": {\n    "title": coalesce(unitBusiness->title, "Sin t\xEDtulo"),\n    "icon": coalesce(unitBusiness->icon, "/default-icon.png"),\n    "slug": coalesce(unitBusiness->slug.current, "default-slug"),\n    "color": coalesce(unitBusiness->color, "bg-gray-100")\n  }\n,\n  orderRank,\n  "coverImage": coalesce(\n    coverImage,\n    components[isActive == true && typeComponent->value == "Heading"][0].imageBackground\n  ),\n  "resumen": coalesce(\n    resumen,\n    array::join(content[_type == "block" && style == "normal"][0].children[].text, " ")\n  ),\n  date,\n  _updatedAt\n  \n      }': GetPostListByUnitBusinessQueryResult;
+    '\n  *[_type == \'post\' && coalesce(isActive, true) == true && slug.current == $slug][0] {\n    \n  \n  _id,\n  title,\n  "slug": slug.current,\n  \n"unitBusiness": {\n    "title": coalesce(unitBusiness->title, "Sin t\xEDtulo"),\n    "icon": coalesce(unitBusiness->icon, "/default-icon.png"),\n    "slug": coalesce(unitBusiness->slug.current, "default-slug"),\n    "color": coalesce(unitBusiness->color, "bg-gray-100")\n  }\n,\n  orderRank,\n  "coverImage": coalesce(\n    coverImage,\n    components[isActive == true && typeComponent->value == "Heading"][0].imageBackground\n  ),\n  "resumen": coalesce(\n    resumen,\n    array::join(content[_type == "block" && style == "normal"][0].children[].text, " ")\n  ),\n  date,\n  _updatedAt\n  ,\n  content,\n  \n  _updatedAt,\n  seo {\n    metaTitle,\n    metaDescription,\n    canonicalUrl,\n    noIndex,\n    ogImage\n  }\n,\n  "author": author->{name, role, credentials, bio, picture},\n  components[isActive == true] | order(orderRank asc) {  // used as template for component in sanity\n  _key,\n  isActive,\n  typeComponent,\n  "typeComponentValue": typeComponent->value,\n  variant,\n  imageBackground,\n  \'backgroundValue\': background-> {  // used as template for background component in sanity\n  name,\n  backgroundMode,\n  imageBackgroundType,\n  colorWithDarkMode,\n  colorList,\n  "colors": colorList[]-> {\n    "lightColor": lightColor{\n      "rgb": rgb,\n      "alpha": alpha,\n      "hex": hex\n    },\n    "darkColor": darkColor{\n      "rgb": rgb,\n      "alpha": alpha,\n      "hex": hex\n    },\n    colorBackground1Position\n  },\n  directionDeg,\n  "layer" : backgroundLayer -> value,\n  responsiveHeight,\n  invertLayoutMobile,\n  invertLayoutDesk\n},\n  content,\n  ctaLinkBanner,\n  PTextBanner,\n  imageContent,\n  imagePosition,\n  videoUrl,\n  videoType,\n  layoutItems,\n  PTextItem,\n  resources,\n  items[isActive == true]  | order(orderRank asc) {\n    _key,\n    isActive,\n    image,\n    icon,\n    svgIcon,\n    svgIconList,\n    "alt": coalesce(image.alt, alt),\n    content,\n    ctaLinkItem,\n  }\n }\n,\n    "tableOfContents" : content[style in [\'h2\', \'h3\']] {\n      _key,\n      style,\n      \'text\':children[0].text \n    }\n  }\n': GetPostDetailQueryResult;
     '*[_type == \'service\' && isActive] | order(unitBusiness->orderRank asc, orderRank asc) {\n      "id": coalesce(slug.current, null),\n      "title": coalesce(title, null),\n      "slug": coalesce(slug.current, null),\n      \n"unitBusiness": {\n    "title": coalesce(unitBusiness->title, "Sin t\xEDtulo"),\n    "icon": coalesce(unitBusiness->icon, "/default-icon.png"),\n    "slug": coalesce(unitBusiness->slug.current, "default-slug"),\n    "color": coalesce(unitBusiness->color, "bg-gray-100")\n  }\n\n    }': GetServicesNavQueryResult;
-    '*[_type == \'service\' && slug.current == $slug][0] {\n    title,  // Fetch the title of the service\n    iconfyIcon,\n    resumen,\n    content,  // Fetch the content of the service\n    "tableOfContents" : content[style in [\'h2\']] {\n      _key,\n      style,\n      \'text\':children[0].text \n    },\n    \n"unitBusiness": {\n    "title": coalesce(unitBusiness->title, "Sin t\xEDtulo"),\n    "icon": coalesce(unitBusiness->icon, "/default-icon.png"),\n    "slug": coalesce(unitBusiness->slug.current, "default-slug"),\n    "color": coalesce(unitBusiness->color, "bg-gray-100")\n  }\n,\n    components[isActive] {  // used as template for component in sanity\n  isActive,\n  typeComponent,\n  "typeComponentValue": typeComponent->value,\n  variant,\n  imageBackground,\n  \'backgroundValue\': background-> {  // used as template for background component in sanity\n  name,\n  backgroundMode,\n  imageBackgroundType,\n  colorWithDarkMode,\n  colorList,\n  "colors": colorList[]-> {\n    "lightColor": lightColor{\n      "rgb": rgb,\n      "alpha": alpha,\n      "hex": hex\n    },\n    "darkColor": darkColor{\n      "rgb": rgb,\n      "alpha": alpha,\n      "hex": hex\n    },\n    colorBackground1Position\n  },\n  directionDeg,\n  "layer" : backgroundLayer -> value,\n  responsiveHeight,\n  invertLayoutMobile,\n  invertLayoutDesk\n},\n  content,\n  ctaLinkBanner,\n  PTextBanner,\n  imageContent,\n  imagePosition,\n  videoUrl,\n  videoType,\n  layoutItems,\n  PTextItem,\n  resources,\n  items[isActive == true]  | order(orderRank asc) {\n    isActive,\n    image,\n    icon,\n    svgIcon,\n    svgIconList,\n    alt,\n    content,\n    ctaLinkItem,\n  }\n }\n  }': GetServiceDetailQueryResult;
-    '\n    *[_type == \'unitBusiness\'] |  order(orderRank asc) {\n      title,\n      "slug": slug.current,\n      color,\n      "services" : services[] -> {\n        title,\n        "slug": slug.current,\n      },  \n      orderRank,\n  }': GetUnitBusinessListQueryResult;
-    '\n    *[_type == \'unitBusiness\' && slug.current == $slug][0] {\n      \n  "id": _id,\n  title,\n  "slug": slug.current,\n  icon,\n  color,\n  description,\n  "services" : services[] -> {\n    title,\n    "slug": slug.current,\n    iconfyIcon,\n    resumen,\n    },\n  components[isActive] {  // used as template for component in sanity\n  isActive,\n  typeComponent,\n  "typeComponentValue": typeComponent->value,\n  variant,\n  imageBackground,\n  \'backgroundValue\': background-> {  // used as template for background component in sanity\n  name,\n  backgroundMode,\n  imageBackgroundType,\n  colorWithDarkMode,\n  colorList,\n  "colors": colorList[]-> {\n    "lightColor": lightColor{\n      "rgb": rgb,\n      "alpha": alpha,\n      "hex": hex\n    },\n    "darkColor": darkColor{\n      "rgb": rgb,\n      "alpha": alpha,\n      "hex": hex\n    },\n    colorBackground1Position\n  },\n  directionDeg,\n  "layer" : backgroundLayer -> value,\n  responsiveHeight,\n  invertLayoutMobile,\n  invertLayoutDesk\n},\n  content,\n  ctaLinkBanner,\n  PTextBanner,\n  imageContent,\n  imagePosition,\n  videoUrl,\n  videoType,\n  layoutItems,\n  PTextItem,\n  resources,\n  items[isActive == true]  | order(orderRank asc) {\n    isActive,\n    image,\n    icon,\n    svgIcon,\n    svgIconList,\n    alt,\n    content,\n    ctaLinkItem,\n  }\n }\n\n    }': GetUnitBusinessDetailQueryResult;
+    '*[_type == \'service\' && isActive == true && slug.current == $slug][0] {\n    title,  // Fetch the title of the service\n    "slug": slug.current,\n    iconfyIcon,\n    resumen,\n    \n  _updatedAt,\n  seo {\n    metaTitle,\n    metaDescription,\n    canonicalUrl,\n    noIndex,\n    ogImage\n  }\n,\n    content,  // Fetch the content of the service\n    "tableOfContents" : content[style in [\'h2\']] {\n      _key,\n      style,\n      \'text\':children[0].text \n    },\n    \n"unitBusiness": {\n    "title": coalesce(unitBusiness->title, "Sin t\xEDtulo"),\n    "icon": coalesce(unitBusiness->icon, "/default-icon.png"),\n    "slug": coalesce(unitBusiness->slug.current, "default-slug"),\n    "color": coalesce(unitBusiness->color, "bg-gray-100")\n  }\n,\n    components[isActive == true] | order(orderRank asc) {  // used as template for component in sanity\n  _key,\n  isActive,\n  typeComponent,\n  "typeComponentValue": typeComponent->value,\n  variant,\n  imageBackground,\n  \'backgroundValue\': background-> {  // used as template for background component in sanity\n  name,\n  backgroundMode,\n  imageBackgroundType,\n  colorWithDarkMode,\n  colorList,\n  "colors": colorList[]-> {\n    "lightColor": lightColor{\n      "rgb": rgb,\n      "alpha": alpha,\n      "hex": hex\n    },\n    "darkColor": darkColor{\n      "rgb": rgb,\n      "alpha": alpha,\n      "hex": hex\n    },\n    colorBackground1Position\n  },\n  directionDeg,\n  "layer" : backgroundLayer -> value,\n  responsiveHeight,\n  invertLayoutMobile,\n  invertLayoutDesk\n},\n  content,\n  ctaLinkBanner,\n  PTextBanner,\n  imageContent,\n  imagePosition,\n  videoUrl,\n  videoType,\n  layoutItems,\n  PTextItem,\n  resources,\n  items[isActive == true]  | order(orderRank asc) {\n    _key,\n    isActive,\n    image,\n    icon,\n    svgIcon,\n    svgIconList,\n    "alt": coalesce(image.alt, alt),\n    content,\n    ctaLinkItem,\n  }\n }\n  }': GetServiceDetailQueryResult;
+    '{\n  "pages": *[\n    _type == "page" &&\n    isActive == true &&\n    defined(slug.current) &&\n    coalesce(seo.noIndex, false) == false\n  ] {\n    "slug": slug.current,\n    isHome,\n    _updatedAt\n  },\n  "posts": *[\n    _type == "post" &&\n    coalesce(isActive, true) == true &&\n    defined(slug.current) &&\n    coalesce(seo.noIndex, false) == false\n  ] {\n    "slug": slug.current,\n    _updatedAt\n  },\n  "services": *[\n    _type == "service" &&\n    isActive == true &&\n    defined(slug.current) &&\n    coalesce(seo.noIndex, false) == false\n  ] {\n    "slug": slug.current,\n    _updatedAt\n  },\n  "unitBusiness": *[\n    _type == "unitBusiness" &&\n    coalesce(isActive, true) == true &&\n    defined(slug.current) &&\n    coalesce(seo.noIndex, false) == false\n  ] {\n    "slug": slug.current,\n    _updatedAt\n  }\n}': SitemapQueryResult;
+    '\n    *[_type == \'unitBusiness\' && coalesce(isActive, true) == true && defined(slug.current)] | order(orderRank asc) {\n      title,\n      "slug": slug.current,\n      color,\n      "services" : services[] -> {\n        title,\n        "slug": slug.current,\n      },  \n      orderRank,\n  }': GetUnitBusinessListQueryResult;
+    '\n    *[_type == \'unitBusiness\' && coalesce(isActive, true) == true && slug.current == $slug][0] {\n      \n  "id": _id,\n  title,\n  "slug": slug.current,\n  icon,\n  color,\n  description,\n  \n  _updatedAt,\n  seo {\n    metaTitle,\n    metaDescription,\n    canonicalUrl,\n    noIndex,\n    ogImage\n  }\n,\n  "services" : services[] -> {\n    title,\n    "slug": slug.current,\n    iconfyIcon,\n    resumen,\n    },\n  components[isActive == true] | order(orderRank asc) {  // used as template for component in sanity\n  _key,\n  isActive,\n  typeComponent,\n  "typeComponentValue": typeComponent->value,\n  variant,\n  imageBackground,\n  \'backgroundValue\': background-> {  // used as template for background component in sanity\n  name,\n  backgroundMode,\n  imageBackgroundType,\n  colorWithDarkMode,\n  colorList,\n  "colors": colorList[]-> {\n    "lightColor": lightColor{\n      "rgb": rgb,\n      "alpha": alpha,\n      "hex": hex\n    },\n    "darkColor": darkColor{\n      "rgb": rgb,\n      "alpha": alpha,\n      "hex": hex\n    },\n    colorBackground1Position\n  },\n  directionDeg,\n  "layer" : backgroundLayer -> value,\n  responsiveHeight,\n  invertLayoutMobile,\n  invertLayoutDesk\n},\n  content,\n  ctaLinkBanner,\n  PTextBanner,\n  imageContent,\n  imagePosition,\n  videoUrl,\n  videoType,\n  layoutItems,\n  PTextItem,\n  resources,\n  items[isActive == true]  | order(orderRank asc) {\n    _key,\n    isActive,\n    image,\n    icon,\n    svgIcon,\n    svgIconList,\n    "alt": coalesce(image.alt, alt),\n    content,\n    ctaLinkItem,\n  }\n }\n\n    }': GetUnitBusinessDetailQueryResult;
   }
 }

--- a/sanity/lib/fetch.ts
+++ b/sanity/lib/fetch.ts
@@ -1,7 +1,5 @@
 import { type ClientPerspective, type QueryParams } from 'next-sanity';
-import { draftMode } from 'next/headers';
-
-import { client } from '@/sanity/lib/client';
+import { cache } from 'react';
 import { sanityFetch as liveFetch } from '@/sanity/lib/live';
 
 import { SettingsQueryResult } from '@/sanity.types';
@@ -18,59 +16,41 @@ export async function sanityFetch<const QueryString extends string>({
   params = {},
   perspective,
   stega,
+  tag,
 }: {
   query: QueryString;
   params?: QueryParams;
-  perspective?: Omit<ClientPerspective, 'raw'>;
+  perspective?: Exclude<ClientPerspective, 'raw'>;
   stega?: boolean;
+  tag?: string;
 }) {
-  const { isEnabled } = await draftMode();
-
-  const actualPerspective =
-    perspective ?? (isEnabled ? 'previewDrafts' : 'published');
-
-  const actualStega =
-    stega ??
-    (actualPerspective === 'previewDrafts' ||
-      process.env.VERCEL_ENV === 'preview');
-
-  //console.log('Actual Stega (Visual Editing):', actualStega);
-  if (actualPerspective === 'previewDrafts') {
-    //console.log("Fetching in draft mode with perspective 'previewDrafts'");
-
-    // Reemplazamos client.fetch por liveFetch
-    const result = await liveFetch({
-      query,
-      params,
-      perspective: 'previewDrafts',
-    });
-
-    return result.data;
-  }
-
-  //console.log("Fetching in production mode with perspective 'published'");
-  return client.fetch(query, params, {
-    stega: actualStega,
-    perspective: 'published',
-    next: {
-      revalidate: 40000,
-    },
+  const result = await liveFetch({
+    query,
+    params,
+    perspective,
+    stega,
+    tag,
   });
+
+  return result.data;
 }
 
 /* SINGLETONS - SETTINGS */
-export async function getSettingsFetch(): Promise<SettingsQueryResult | null> {
-  const query = settingsQuery;
-  try {
-    const data = (await sanityFetch({
-      query,
-    })) as SettingsQueryResult | null;
-    if (!data || (Array.isArray(data) && data.length === 0)) {
-      return null; // Si no hay datos, retornamos null
+export const getSettingsFetch = cache(
+  async function getSettingsFetch(): Promise<SettingsQueryResult | null> {
+    const query = settingsQuery;
+    try {
+      const data = (await sanityFetch({
+        query,
+        tag: 'settings',
+      })) as SettingsQueryResult | null;
+      if (!data || (Array.isArray(data) && data.length === 0)) {
+        return null; // Si no hay datos, retornamos null
+      }
+      return data;
+    } catch (error) {
+      console.error('Error fetching banner:', error);
+      throw error; // Opcionalmente vuelve a lanzar o maneja el error de acuerdo a tu necesidad
     }
-    return data;
-  } catch (error) {
-    console.error('Error fetching banner:', error);
-    throw error; // Opcionalmente vuelve a lanzar o maneja el error de acuerdo a tu necesidad
   }
-}
+);

--- a/sanity/lib/fetchs/page.fetch.ts
+++ b/sanity/lib/fetchs/page.fetch.ts
@@ -3,26 +3,30 @@ import {
   GetPagesNavQueryResult,
 } from '@/sanity.types';
 import { sanityFetch } from '../fetch';
+import { cache } from 'react';
 import { getPageDetailQuery, getPagesNavQuery } from '../queries/page.query';
 
 /* MAIN PAGES */
-export async function getPagesNavFetch(): Promise<GetPagesNavQueryResult | null> {
-  const query = getPagesNavQuery;
-  try {
-    const data = (await sanityFetch({
-      query,
-    })) as GetPagesNavQueryResult | null;
-    if (!data || (Array.isArray(data) && data.length === 0)) {
-      return null; // Si no hay datos, retornamos null
+export const getPagesNavFetch = cache(
+  async function getPagesNavFetch(): Promise<GetPagesNavQueryResult | null> {
+    const query = getPagesNavQuery;
+    try {
+      const data = (await sanityFetch({
+        query,
+        tag: 'pages-nav',
+      })) as GetPagesNavQueryResult | null;
+      if (!data || (Array.isArray(data) && data.length === 0)) {
+        return null; // Si no hay datos, retornamos null
+      }
+      return data;
+    } catch (error) {
+      console.error('Error fetching banner:', error);
+      throw error; // Opcionalmente vuelve a lanzar o maneja el error de acuerdo a tu necesidad
     }
-    return data;
-  } catch (error) {
-    console.error('Error fetching banner:', error);
-    throw error; // Opcionalmente vuelve a lanzar o maneja el error de acuerdo a tu necesidad
   }
-}
+);
 
-export async function getPageBySlugFetch(
+export const getPageBySlugFetch = cache(async function getPageBySlugFetch(
   slug: string
 ): Promise<GetPageDetailQueryResult | null> {
   // Remove extra quotes if any
@@ -32,6 +36,7 @@ export async function getPageBySlugFetch(
     const data = (await sanityFetch({
       query,
       params,
+        tag: 'page-detail',
     })) as GetPageDetailQueryResult | null;
     if (!data) {
       return null; // Si no hay datos, retornamos null
@@ -42,4 +47,4 @@ export async function getPageBySlugFetch(
     console.error('Error fetching banner:', error);
     throw error; // Opcionalmente vuelve a lanzar o maneja el error de acuerdo a tu necesidad
   }
-}
+});

--- a/sanity/lib/fetchs/post.fetch.ts
+++ b/sanity/lib/fetchs/post.fetch.ts
@@ -9,47 +9,54 @@ import {
   getPostListQuery,
 } from '../queries/post.query';
 import { sanityFetch } from '../fetch';
+import { cache } from 'react';
 
-export async function getPostListFetch(): Promise<GetPostListQueryResult | null> {
-  // Remove extra quotes if any
-  const query = getPostListQuery;
-  try {
-    const posts = (await sanityFetch({
-      query,
-    })) as GetPostListQueryResult | null;
+export const getPostListFetch = cache(
+  async function getPostListFetch(): Promise<GetPostListQueryResult | null> {
+    // Remove extra quotes if any
+    const query = getPostListQuery;
+    try {
+      const posts = (await sanityFetch({
+        query,
+        tag: 'posts-list',
+      })) as GetPostListQueryResult | null;
 
-    // Si service es null, retornamos null
-    if (!posts) return null;
-    return posts;
-  } catch (error) {
-    console.error('Error fetching list of posts:', error);
-    throw error;
+      // Si service es null, retornamos null
+      if (!posts) return null;
+      return posts;
+    } catch (error) {
+      console.error('Error fetching list of posts:', error);
+      throw error;
+    }
   }
-}
+);
 
-export async function getPostListByUnitBusinessFetch(
-  slug: string
-): Promise<GetPostListByUnitBusinessQueryResult | null> {
-  // Remove extra quotes if any
-  const sanitizedSlug = slug.replace(/"/g, '');
-  const query = getPostListByUnitBusinessQuery;
-  const params = { slug: sanitizedSlug };
-  try {
-    const posts = (await sanityFetch({
-      query,
-      params,
-    })) as GetPostListByUnitBusinessQueryResult | null;
+export const getPostListByUnitBusinessFetch = cache(
+  async function getPostListByUnitBusinessFetch(
+    slug: string
+  ): Promise<GetPostListByUnitBusinessQueryResult | null> {
+    // Remove extra quotes if any
+    const sanitizedSlug = slug.replace(/"/g, '');
+    const query = getPostListByUnitBusinessQuery;
+    const params = { slug: sanitizedSlug };
+    try {
+      const posts = (await sanityFetch({
+        query,
+        params,
+        tag: 'posts-unit',
+      })) as GetPostListByUnitBusinessQueryResult | null;
 
-    // Si service es null, retornamos null
-    if (!posts) return null;
-    return posts;
-  } catch (error) {
-    console.error('Error fetching post by slug:', error);
-    throw error;
+      // Si service es null, retornamos null
+      if (!posts) return null;
+      return posts;
+    } catch (error) {
+      console.error('Error fetching post by slug:', error);
+      throw error;
+    }
   }
-}
+);
 
-export async function getPostBySlugFetch({
+export const getPostBySlugFetch = cache(async function getPostBySlugFetch({
   slug,
 }: {
   slug: string;
@@ -63,6 +70,7 @@ export async function getPostBySlugFetch({
     const post = (await sanityFetch({
       query,
       params,
+        tag: 'post-detail',
     })) as GetPostDetailQueryResult | null;
 
     if (!post) return null;
@@ -71,4 +79,4 @@ export async function getPostBySlugFetch({
     console.error('Error fetching post by slug:', error);
     throw error;
   }
-}
+});

--- a/sanity/lib/fetchs/service.fetch.ts
+++ b/sanity/lib/fetchs/service.fetch.ts
@@ -7,28 +7,32 @@ import {
   getServicesNavQuery,
 } from '../queries/service.query';
 import { sanityFetch } from '../fetch';
+import { cache } from 'react';
 
 /* SERVICES */
-export async function getServicesNavFetch(): Promise<GetServicesNavQueryResult | null> {
-  // Remove extra quotes if any
-  const query = getServicesNavQuery;
+export const getServicesNavFetch = cache(
+  async function getServicesNavFetch(): Promise<GetServicesNavQueryResult | null> {
+    // Remove extra quotes if any
+    const query = getServicesNavQuery;
 
-  try {
-    const services = (await sanityFetch({
-      query,
-    })) as GetServicesNavQueryResult | null;
-    // Si service es null, retornamos null
-    if (!services || (Array.isArray(services) && services.length === 0)) {
-      return null; // Si no hay datos, retornamos null
+    try {
+      const services = (await sanityFetch({
+        query,
+        tag: 'services-nav',
+      })) as GetServicesNavQueryResult | null;
+      // Si service es null, retornamos null
+      if (!services || (Array.isArray(services) && services.length === 0)) {
+        return null; // Si no hay datos, retornamos null
+      }
+      return services;
+    } catch (error) {
+      console.error('Error fetching service by slug:', error);
+      throw error; // Opcionalmente vuelve a lanzar o maneja el error de acuerdo a tu necesidad
     }
-    return services;
-  } catch (error) {
-    console.error('Error fetching service by slug:', error);
-    throw error; // Opcionalmente vuelve a lanzar o maneja el error de acuerdo a tu necesidad
   }
-}
+);
 
-export async function getServiceBySlugFetch(
+export const getServiceBySlugFetch = cache(async function getServiceBySlugFetch(
   slug: string
 ): Promise<GetServiceDetailQueryResult | null> {
   // Remove extra quotes if any
@@ -39,6 +43,7 @@ export async function getServiceBySlugFetch(
     const service = (await sanityFetch({
       query,
       params,
+        tag: 'service-detail',
     })) as GetServiceDetailQueryResult | null;
 
     // Si service es null, retornamos null
@@ -51,4 +56,4 @@ export async function getServiceBySlugFetch(
     console.error('Error fetching service by slug:', error);
     throw error; // Opcionalmente vuelve a lanzar o maneja el error de acuerdo a tu necesidad
   }
-}
+});

--- a/sanity/lib/fetchs/sitemap.fetch.ts
+++ b/sanity/lib/fetchs/sitemap.fetch.ts
@@ -1,0 +1,12 @@
+import { cache } from 'react';
+import { SitemapQueryResult } from '@/sanity.types';
+import { sanityFetch } from '../fetch';
+import { sitemapQuery } from '../queries/sitemap.query';
+
+export const getSitemapFetch = cache(
+  async (): Promise<SitemapQueryResult> =>
+    (await sanityFetch({
+      query: sitemapQuery,
+      tag: 'sitemap',
+    })) as SitemapQueryResult
+);

--- a/sanity/lib/fetchs/unitBusiness.fetch.ts
+++ b/sanity/lib/fetchs/unitBusiness.fetch.ts
@@ -7,41 +7,48 @@ import {
   getUnitBusinessListQuery,
 } from '../queries/unitBusiness.query';
 import { sanityFetch } from '../fetch';
+import { cache } from 'react';
 
-export async function getUnitBusinessListFetch(): Promise<GetUnitBusinessListQueryResult | null> {
-  // Remove extra quotes if any
-  const query = getUnitBusinessListQuery;
-  try {
-    const unitsBusiness = (await sanityFetch({
-      query,
-    })) as GetUnitBusinessListQueryResult | null;
+export const getUnitBusinessListFetch = cache(
+  async function getUnitBusinessListFetch(): Promise<GetUnitBusinessListQueryResult | null> {
+    // Remove extra quotes if any
+    const query = getUnitBusinessListQuery;
+    try {
+      const unitsBusiness = (await sanityFetch({
+        query,
+        tag: 'unit-business-list',
+      })) as GetUnitBusinessListQueryResult | null;
 
-    // Si service es null, retornamos null
-    if (!unitsBusiness) return null;
-    return unitsBusiness;
-  } catch (error) {
-    console.error('Error fetching unitsBusiness:', error);
-    throw error;
+      // Si service es null, retornamos null
+      if (!unitsBusiness) return null;
+      return unitsBusiness;
+    } catch (error) {
+      console.error('Error fetching unitsBusiness:', error);
+      throw error;
+    }
   }
-}
+);
 
-export async function getUnitBusinessBySlugFetch(
-  slug: string
-): Promise<GetUnitBusinessDetailQueryResult | null> {
-  // Remove extra quotes if any
-  const query = getUnitBusinessDetailQuery;
-  const params = { slug: slug.replace(/"/g, '') }; // Pass the sanitized slug
-  try {
-    const unitsBusiness = (await sanityFetch({
-      query,
-      params,
-    })) as GetUnitBusinessDetailQueryResult | null;
+export const getUnitBusinessBySlugFetch = cache(
+  async function getUnitBusinessBySlugFetch(
+    slug: string
+  ): Promise<GetUnitBusinessDetailQueryResult | null> {
+    // Remove extra quotes if any
+    const query = getUnitBusinessDetailQuery;
+    const params = { slug: slug.replace(/"/g, '') }; // Pass the sanitized slug
+    try {
+      const unitsBusiness = (await sanityFetch({
+        query,
+        params,
+        tag: 'unit-business-detail',
+      })) as GetUnitBusinessDetailQueryResult | null;
 
-    // Si service es null, retornamos null
-    if (!unitsBusiness) return null;
-    return unitsBusiness;
-  } catch (error) {
-    console.error('Error fetching unitsBusiness:', error);
-    throw error;
+      // Si service es null, retornamos null
+      if (!unitsBusiness) return null;
+      return unitsBusiness;
+    } catch (error) {
+      console.error('Error fetching unitsBusiness:', error);
+      throw error;
+    }
   }
-}
+);

--- a/sanity/lib/live.ts
+++ b/sanity/lib/live.ts
@@ -1,21 +1,21 @@
 'use server';
 import { createClient, defineLive } from 'next-sanity';
 import { token } from './token';
+import { dataset, projectId, studioUrl } from './api';
 
 const client = createClient({
-  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
-  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET,
-  useCdn: false,
+  projectId,
+  dataset,
+  useCdn: true,
   apiVersion: 'vX', // Target the experimental API version
-  stega: { studioUrl: '/studio' },
+  stega: { studioUrl },
 });
-
-if (!token) {
-  throw new Error('Missing SANITY_API_READ_TOKEN');
-}
 
 export const { sanityFetch, SanityLive } = defineLive({
   client,
   serverToken: token,
   browserToken: token,
+  fetchOptions: {
+    revalidate: 3600,
+  },
 });

--- a/sanity/lib/queries/component.query.ts
+++ b/sanity/lib/queries/component.query.ts
@@ -25,6 +25,7 @@ const background = /* groq */ ` // used as template for background component in 
 `;
 
 export const componentFields = /* groq */ ` // used as template for component in sanity
+  _key,
   isActive,
   typeComponent,
   "typeComponentValue": typeComponent->value,
@@ -42,12 +43,13 @@ export const componentFields = /* groq */ ` // used as template for component in
   PTextItem,
   resources,
   items[isActive == true]  | order(orderRank asc) {
+    _key,
     isActive,
     image,
     icon,
     svgIcon,
     svgIconList,
-    alt,
+    "alt": coalesce(image.alt, alt),
     content,
     ctaLinkItem,
   }

--- a/sanity/lib/queries/page.query.ts
+++ b/sanity/lib/queries/page.query.ts
@@ -1,9 +1,10 @@
 import { defineQuery, groq } from 'next-sanity';
 import { componentFields } from './component.query';
+import { seoFields } from './seo.query';
 
 /* PAGES - NAVIGATION */
 export const getPagesNavQuery = defineQuery(groq`
-    *[_type == 'page' && isActive] | order(orderRank asc) {
+    *[_type == 'page' && isActive == true && defined(slug.current)] | order(orderRank asc) {
       "id": coalesce(_id, ""), 
       "name": coalesce(name, title),
       title,
@@ -23,11 +24,13 @@ const pageFields = /* groq */ `
     "slug": slug.current,
     isActive,
     title,
+    resumen,
     content,
-    components[isActive]  { ${componentFields} }
+    ${seoFields},
+    components[isActive == true] | order(orderRank asc) { ${componentFields} }
 `;
 
 export const getPageDetailQuery = defineQuery(groq`
-    *[_type == 'page' && slug.current == $slug][0] {
+    *[_type == 'page' && isActive == true && slug.current == $slug][0] {
     ${pageFields}
     }`);

--- a/sanity/lib/queries/post.query.ts
+++ b/sanity/lib/queries/post.query.ts
@@ -1,37 +1,50 @@
 import { defineQuery, groq } from 'next-sanity';
 import { unitBusiness } from './unitBusiness.query';
 import { componentFields } from './component.query';
+import { seoFields } from './seo.query';
 
 /* BLOG - POST */
-export const post = /* groq */ `
+export const postListFields = /* groq */ `
+  _id,
   title,
-  slug,
+  "slug": slug.current,
   ${unitBusiness},
   orderRank,
-  components[isActive] | order(orderRank asc) { ${componentFields} },
+  "coverImage": coalesce(
+    coverImage,
+    components[isActive == true && typeComponent->value == "Heading"][0].imageBackground
+  ),
   "resumen": coalesce(
     resumen,
     array::join(content[_type == "block" && style == "normal"][0].children[].text, " ")
   ),
-  date
+  date,
+  _updatedAt
   `;
+
+export const postDetailFields = /* groq */ `
+  ${postListFields},
+  content,
+  ${seoFields},
+  "author": author->{name, role, credentials, bio, picture},
+  components[isActive == true] | order(orderRank asc) { ${componentFields} }
+`;
 
 /* BLOG - LISTA DE POSTS */
 export const getPostListQuery = defineQuery(groq`
-    *[_type == 'post'] | order(orderRank desc) {
-      ${post}
+    *[_type == 'post' && coalesce(isActive, true) == true && defined(slug.current)] | order(date desc, orderRank desc) {
+      ${postListFields}
       }`);
 
 export const getPostListByUnitBusinessQuery = defineQuery(groq`
-    *[_type == 'post' && unitBusiness->slug.current == $slug ] | order(orderRank desc){
-      ${post}
+    *[_type == 'post' && coalesce(isActive, true) == true && defined(slug.current) && unitBusiness->slug.current == $slug] | order(date desc, orderRank desc) {
+      ${postListFields}
       }`);
 
 /* BLOG - DETALLE DE POST */
 export const getPostDetailQuery = defineQuery(groq`
-  *[_type == 'post' && slug.current == $slug][0] {
-    ${post},
-    content,
+  *[_type == 'post' && coalesce(isActive, true) == true && slug.current == $slug][0] {
+    ${postDetailFields},
     "tableOfContents" : content[style in ['h2', 'h3']] {
       _key,
       style,

--- a/sanity/lib/queries/seo.query.ts
+++ b/sanity/lib/queries/seo.query.ts
@@ -1,0 +1,10 @@
+export const seoFields = /* groq */ `
+  _updatedAt,
+  seo {
+    metaTitle,
+    metaDescription,
+    canonicalUrl,
+    noIndex,
+    ogImage
+  }
+`;

--- a/sanity/lib/queries/service.query.ts
+++ b/sanity/lib/queries/service.query.ts
@@ -1,6 +1,7 @@
 import { defineQuery, groq } from 'next-sanity';
 import { unitBusiness } from './unitBusiness.query';
 import { componentFields } from './component.query';
+import { seoFields } from './seo.query';
 
 /* SERVICES - NAVIGATION */
 export const getServicesNavQuery = defineQuery(
@@ -13,10 +14,12 @@ export const getServicesNavQuery = defineQuery(
 );
 /* SERVICES - DETALLE */
 export const getServiceDetailQuery = defineQuery(
-  groq`*[_type == 'service' && slug.current == $slug][0] {
+  groq`*[_type == 'service' && isActive == true && slug.current == $slug][0] {
     title,  // Fetch the title of the service
+    "slug": slug.current,
     iconfyIcon,
     resumen,
+    ${seoFields},
     content,  // Fetch the content of the service
     "tableOfContents" : content[style in ['h2']] {
       _key,
@@ -24,6 +27,6 @@ export const getServiceDetailQuery = defineQuery(
       'text':children[0].text 
     },
     ${unitBusiness},
-    components[isActive] { ${componentFields} }
+    components[isActive == true] | order(orderRank asc) { ${componentFields} }
   }`
 );

--- a/sanity/lib/queries/sitemap.query.ts
+++ b/sanity/lib/queries/sitemap.query.ts
@@ -1,0 +1,41 @@
+import { defineQuery, groq } from 'next-sanity';
+
+export const sitemapQuery = defineQuery(groq`{
+  "pages": *[
+    _type == "page" &&
+    isActive == true &&
+    defined(slug.current) &&
+    coalesce(seo.noIndex, false) == false
+  ] {
+    "slug": slug.current,
+    isHome,
+    _updatedAt
+  },
+  "posts": *[
+    _type == "post" &&
+    coalesce(isActive, true) == true &&
+    defined(slug.current) &&
+    coalesce(seo.noIndex, false) == false
+  ] {
+    "slug": slug.current,
+    _updatedAt
+  },
+  "services": *[
+    _type == "service" &&
+    isActive == true &&
+    defined(slug.current) &&
+    coalesce(seo.noIndex, false) == false
+  ] {
+    "slug": slug.current,
+    _updatedAt
+  },
+  "unitBusiness": *[
+    _type == "unitBusiness" &&
+    coalesce(isActive, true) == true &&
+    defined(slug.current) &&
+    coalesce(seo.noIndex, false) == false
+  ] {
+    "slug": slug.current,
+    _updatedAt
+  }
+}`);

--- a/sanity/lib/queries/unitBusiness.query.ts
+++ b/sanity/lib/queries/unitBusiness.query.ts
@@ -1,5 +1,6 @@
 import { defineQuery, groq } from 'next-sanity';
 import { componentFields } from './component.query';
+import { seoFields } from './seo.query';
 
 export const unitBusiness = /* groq */ `
 "unitBusiness": {
@@ -11,7 +12,7 @@ export const unitBusiness = /* groq */ `
 `;
 
 export const getUnitBusinessListQuery = defineQuery(groq`
-    *[_type == 'unitBusiness'] |  order(orderRank asc) {
+    *[_type == 'unitBusiness' && coalesce(isActive, true) == true && defined(slug.current)] | order(orderRank asc) {
       title,
       "slug": slug.current,
       color,
@@ -29,16 +30,17 @@ const ubFields = /* groq */ `
   icon,
   color,
   description,
+  ${seoFields},
   "services" : services[] -> {
     title,
     "slug": slug.current,
     iconfyIcon,
     resumen,
     },
-  components[isActive] { ${componentFields} }
+  components[isActive == true] | order(orderRank asc) { ${componentFields} }
 `;
 
 export const getUnitBusinessDetailQuery = defineQuery(groq`
-    *[_type == 'unitBusiness' && slug.current == $slug][0] {
+    *[_type == 'unitBusiness' && coalesce(isActive, true) == true && slug.current == $slug][0] {
       ${ubFields}
     }`);

--- a/sanity/lib/seo.ts
+++ b/sanity/lib/seo.ts
@@ -1,0 +1,83 @@
+import type { Metadata } from 'next';
+import { resolveOpenGraphImage } from './utils';
+
+type SeoImage = Parameters<typeof resolveOpenGraphImage>[0];
+
+export type SeoDocument = {
+  title?: string | null;
+  resumen?: string | null;
+  _updatedAt?: string | null;
+  seo?: {
+    metaTitle?: string | null;
+    metaDescription?: string | null;
+    canonicalUrl?: string | null;
+    noIndex?: boolean | null;
+    ogImage?: SeoImage;
+  } | null;
+};
+
+export function getSiteUrl(configuredUrl?: string | null) {
+  const value =
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    configuredUrl ||
+    process.env.VERCEL_PROJECT_PRODUCTION_URL ||
+    'www.abogadossanfelipe.cl';
+
+  const withProtocol = /^https?:\/\//.test(value) ? value : `https://${value}`;
+  return withProtocol.replace(/\/$/, '');
+}
+
+export function buildDocumentMetadata({
+  document,
+  path,
+  fallbackImage,
+  type = 'website',
+}: {
+  document: SeoDocument | null | undefined;
+  path: string;
+  fallbackImage?: SeoImage;
+  type?: 'article' | 'website';
+}): Metadata {
+  if (!document) {
+    return {
+      title: 'Contenido no encontrado',
+      robots: { index: false, follow: false },
+    };
+  }
+
+  const title = document.seo?.metaTitle || document.title || '';
+  const description =
+    document.seo?.metaDescription ||
+    document.resumen ||
+    undefined;
+  const image = resolveOpenGraphImage(
+    document.seo?.ogImage || fallbackImage
+  );
+  const canonical = document.seo?.canonicalUrl || path;
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    robots: document.seo?.noIndex
+      ? { index: false, follow: false }
+      : undefined,
+    openGraph: {
+      title,
+      description,
+      images: image,
+      type,
+      url: canonical,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: image,
+    },
+  };
+}
+
+export function serializeJsonLd(value: unknown) {
+  return JSON.stringify(value).replace(/</g, '\\u003c');
+}

--- a/sanity/lib/token.ts
+++ b/sanity/lib/token.ts
@@ -1,4 +1,1 @@
 export const token = process.env.SANITY_API_READ_TOKEN;
-if (!token) {
-  throw new Error('Missing SANITY_API_READ_TOKEN');
-}

--- a/sanity/lib/utils.ts
+++ b/sanity/lib/utils.ts
@@ -12,15 +12,7 @@ const imageBuilder = createImageUrlBuilder({
 export const urlForImage = (
   source: { asset?: { _ref?: string } } | null | undefined
 ) => {
-  // Ensure that source image contains a valid reference
-  if (!source?.asset?._ref) {
-    // If there's no valid reference, create a fallback source
-    source = {
-      asset: {
-        _ref: 'image-aa5cf84793776bbe4a334f44bd118fb6e057d26f-667x658-jpg',
-      },
-    };
-  }
+  if (!source?.asset?._ref) return undefined;
 
   // Return the URL for the image
   return imageBuilder?.image(source).auto('format').fit('max');
@@ -28,7 +20,7 @@ export const urlForImage = (
 
 export function resolveOpenGraphImage(image: any, width = 1200, height = 627) {
   if (!image) return;
-  const url = urlForImage(image)?.width(1200).height(627).fit('crop').url();
+  const url = urlForImage(image)?.width(width).height(height).fit('crop').url();
   if (!url) return;
   return { url, alt: image?.alt as string, width, height };
 }
@@ -87,7 +79,7 @@ export async function isUniqueTrueForField(
   const params = { draft: `drafts.${id}`, published: id };
 
   // Consulta para verificar que solo haya un documento con el campo `true`
-  const query = `!defined(*[!(_id in [$draft, $published]) && ${document._type} == $type && ${document._type}.isHome == true][0]._id)`;
+  const query = `!defined(*[!(_id in [$draft, $published]) && _type == $type && isHome == true][0]._id)`;
   const result = await client.fetch(query, { ...params, type: document._type });
 
   // Si ya existe un documento con el valor `true`, regresa un error

--- a/sanity/schemas/documents/author.ts
+++ b/sanity/schemas/documents/author.ts
@@ -1,32 +1,50 @@
-import { UserIcon } from "@sanity/icons";
-import { defineField, defineType } from "sanity";
+import { UserIcon } from '@sanity/icons';
+import { defineField, defineType } from 'sanity';
 
 export default defineType({
-  name: "author",
-  title: "Author",
+  name: 'author',
+  title: 'Author',
   icon: UserIcon,
-  type: "document",
+  type: 'document',
   fields: [
     defineField({
-      name: "name",
-      title: "Name",
-      type: "string",
+      name: 'name',
+      title: 'Name',
+      type: 'string',
       validation: (rule) => rule.required(),
     }),
     defineField({
-      name: "picture",
-      title: "Picture",
-      type: "image",
+      name: 'role',
+      title: 'Cargo o especialidad',
+      type: 'string',
+    }),
+    defineField({
+      name: 'credentials',
+      title: 'Credenciales',
+      description: 'Colegiatura, estudios o experiencia relevante.',
+      type: 'array',
+      of: [{ type: 'string' }],
+    }),
+    defineField({
+      name: 'bio',
+      title: 'Biografía breve',
+      type: 'text',
+      rows: 4,
+    }),
+    defineField({
+      name: 'picture',
+      title: 'Picture',
+      type: 'image',
       fields: [
         {
-          name: "alt",
-          type: "string",
-          title: "Alternative text",
-          description: "Important for SEO and accessiblity.",
+          name: 'alt',
+          type: 'string',
+          title: 'Alternative text',
+          description: 'Important for SEO and accessiblity.',
           validation: (rule) => {
             return rule.custom((alt, context) => {
               if ((context.document?.picture as any)?.asset?._ref && !alt) {
-                return "Required";
+                return 'Required';
               }
               return true;
             });
@@ -36,7 +54,7 @@ export default defineType({
       options: {
         hotspot: true,
         aiAssist: {
-          imageDescriptionField: "alt",
+          imageDescriptionField: 'alt',
         },
       },
       validation: (rule) => rule.required(),

--- a/sanity/schemas/documents/banner.ts
+++ b/sanity/schemas/documents/banner.ts
@@ -75,6 +75,13 @@ export default defineType({
       options: {
         hotspot: true,
       },
+      fields: [
+        defineField({
+          name: 'alt',
+          title: 'Texto alternativo',
+          type: 'string',
+        }),
+      ],
       group: 'background',
     }),
     // GROUP VIDEO
@@ -124,6 +131,22 @@ export default defineType({
       options: {
         hotspot: true,
       },
+      fields: [
+        defineField({
+          name: 'alt',
+          title: 'Texto alternativo',
+          type: 'string',
+          validation: (rule) =>
+            rule.custom((alt, context) => {
+              const parent = context.parent as
+                | { asset?: { _ref?: string } }
+                | undefined;
+              return parent?.asset?._ref && !alt
+                ? 'Agrega un texto alternativo para la imagen.'
+                : true;
+            }),
+        }),
+      ],
       group: 'content',
     }),
     defineField({

--- a/sanity/schemas/documents/item.ts
+++ b/sanity/schemas/documents/item.ts
@@ -5,7 +5,7 @@ import {
   orderRankOrdering,
 } from '@sanity/orderable-document-list';
 
-export default  defineType({
+export default defineType({
   name: 'item',
   title: 'Item',
   type: 'document', // Tipo de documento
@@ -25,6 +25,13 @@ export default  defineType({
       options: {
         hotspot: true,
       },
+      fields: [
+        defineField({
+          name: 'alt',
+          title: 'Texto alternativo',
+          type: 'string',
+        }),
+      ],
     }),
     defineField({
       name: 'alt',

--- a/sanity/schemas/documents/page.ts
+++ b/sanity/schemas/documents/page.ts
@@ -53,6 +53,11 @@ const page = defineType({
       type: 'string',
     }),
     defineField({
+      name: 'seo',
+      title: 'SEO y redes sociales',
+      type: 'seo',
+    }),
+    defineField({
       name: 'isHome',
       title: 'Página de inicio',
       type: 'boolean',

--- a/sanity/schemas/documents/post.ts
+++ b/sanity/schemas/documents/post.ts
@@ -15,6 +15,12 @@ export default defineType({
   fields: [
     orderRankField({ type: 'post' }),
     defineField({
+      name: 'isActive',
+      title: 'Publicar en el sitio',
+      type: 'boolean',
+      initialValue: true,
+    }),
+    defineField({
       name: 'title',
       title: 'Título',
       type: 'string',
@@ -67,6 +73,23 @@ export default defineType({
         },
         {
           type: 'image',
+          options: { hotspot: true },
+          fields: [
+            defineField({
+              name: 'alt',
+              title: 'Texto alternativo',
+              type: 'string',
+              validation: (rule) =>
+                rule.custom((alt, context) => {
+                  const parent = context.parent as
+                    | { asset?: { _ref?: string } }
+                    | undefined;
+                  return parent?.asset?._ref && !alt
+                    ? 'Agrega un texto alternativo para la imagen.'
+                    : true;
+                }),
+            }),
+          ],
         },
       ],
     }),
@@ -77,11 +100,49 @@ export default defineType({
       to: [{ type: 'unitBusiness' }],
     }),
     defineField({
+      name: 'coverImage',
+      title: 'Imagen principal',
+      description:
+        'Se utiliza en listados, Open Graph y tarjetas del artículo.',
+      type: 'image',
+      options: {
+        hotspot: true,
+        aiAssist: { imageDescriptionField: 'alt' },
+      },
+      fields: [
+        defineField({
+          name: 'alt',
+          title: 'Texto alternativo',
+          type: 'string',
+          validation: (rule) =>
+            rule.custom((alt, context) => {
+              const parent = context.parent as
+                | { asset?: { _ref?: string } }
+                | undefined;
+              return parent?.asset?._ref && !alt
+                ? 'Agrega un texto alternativo para la imagen.'
+                : true;
+            }),
+        }),
+      ],
+    }),
+    defineField({
+      name: 'author',
+      title: 'Autor',
+      type: 'reference',
+      to: [{ type: 'author' }],
+    }),
+    defineField({
       name: 'resumen',
       title: 'Resumen',
       description:
         'Texto para lista de Posts. (Si está vacio se mostrarán los 100 primeros caracteres del primer parrafo: estilo normal")',
       type: 'text',
+    }),
+    defineField({
+      name: 'seo',
+      title: 'SEO y redes sociales',
+      type: 'seo',
     }),
     defineField({
       name: 'components',

--- a/sanity/schemas/documents/service.ts
+++ b/sanity/schemas/documents/service.ts
@@ -48,6 +48,11 @@ export default defineType({
       type: 'text',
     }),
     defineField({
+      name: 'seo',
+      title: 'SEO y redes sociales',
+      type: 'seo',
+    }),
+    defineField({
       name: 'content',
       title: 'Detalles del servicio',
       type: 'array',
@@ -55,6 +60,23 @@ export default defineType({
         { type: 'block' },
         {
           type: 'image',
+          options: { hotspot: true },
+          fields: [
+            defineField({
+              name: 'alt',
+              title: 'Texto alternativo',
+              type: 'string',
+              validation: (rule) =>
+                rule.custom((alt, context) => {
+                  const parent = context.parent as
+                    | { asset?: { _ref?: string } }
+                    | undefined;
+                  return parent?.asset?._ref && !alt
+                    ? 'Agrega un texto alternativo para la imagen.'
+                    : true;
+                }),
+            }),
+          ],
         },
       ], // Para contenido enriquecido
     }),

--- a/sanity/schemas/documents/unitBusiness.ts
+++ b/sanity/schemas/documents/unitBusiness.ts
@@ -14,6 +14,12 @@ export default defineType({
   fields: [
     orderRankField({ type: 'unitBusiness' }),
     defineField({
+      name: 'isActive',
+      title: 'Publicar en el sitio',
+      type: 'boolean',
+      initialValue: true,
+    }),
+    defineField({
       name: 'title',
       title: 'Título',
       type: 'string',
@@ -27,6 +33,7 @@ export default defineType({
         source: 'title',
         maxLength: 96,
       },
+      validation: (rule) => rule.required(),
     }),
     defineField({
       name: 'icon',
@@ -60,6 +67,11 @@ export default defineType({
       title: 'Descripción',
       type: 'array',
       of: [{ type: 'block' }, { type: 'image' }],
+    }),
+    defineField({
+      name: 'seo',
+      title: 'SEO y redes sociales',
+      type: 'seo',
     }),
     defineField({
       name: 'services',

--- a/sanity/schemas/objects/seo.ts
+++ b/sanity/schemas/objects/seo.ts
@@ -1,0 +1,73 @@
+import { defineField, defineType } from 'sanity';
+
+export default defineType({
+  name: 'seo',
+  title: 'SEO y redes sociales',
+  type: 'object',
+  options: {
+    collapsible: true,
+    collapsed: false,
+  },
+  fields: [
+    defineField({
+      name: 'metaTitle',
+      title: 'Título SEO',
+      description:
+        'Si se deja vacío se utilizará el título principal del documento.',
+      type: 'string',
+      validation: (rule) =>
+        rule.max(60).warning('Intenta mantener el título bajo 60 caracteres.'),
+    }),
+    defineField({
+      name: 'metaDescription',
+      title: 'Descripción SEO',
+      description:
+        'Resumen único pensado para resultados de búsqueda y redes sociales.',
+      type: 'text',
+      rows: 3,
+      validation: (rule) =>
+        rule
+          .min(120)
+          .max(160)
+          .warning('La longitud recomendada está entre 120 y 160 caracteres.'),
+    }),
+    defineField({
+      name: 'canonicalUrl',
+      title: 'URL canónica alternativa',
+      description:
+        'Úsala solo cuando este contenido deba atribuirse a otra URL.',
+      type: 'url',
+      validation: (rule) => rule.uri({ scheme: ['http', 'https'] }),
+    }),
+    defineField({
+      name: 'noIndex',
+      title: 'Excluir de buscadores',
+      description: 'Añade noindex y excluye el documento del sitemap.',
+      type: 'boolean',
+      initialValue: false,
+    }),
+    defineField({
+      name: 'ogImage',
+      title: 'Imagen para compartir',
+      description: 'Formato recomendado: 1200 × 630 px.',
+      type: 'image',
+      options: { hotspot: true },
+      fields: [
+        defineField({
+          name: 'alt',
+          title: 'Texto alternativo',
+          type: 'string',
+          validation: (rule) =>
+            rule.custom((alt, context) => {
+              const parent = context.parent as
+                | { asset?: { _ref?: string } }
+                | undefined;
+              return parent?.asset?._ref && !alt
+                ? 'Agrega un texto alternativo para la imagen.'
+                : true;
+            }),
+        }),
+      ],
+    }),
+  ],
+});

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,15 +13,16 @@ const config: Config = {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['var(--font-inter)'],
-        inter: ['var(--font-inter)', 'sans-serif'],
-        roboto: ['var(--font-roboto-flex)', 'sans-serif'],
-        robotoslab: ['var(--font-roboto-slab)', 'sans-serif'],
+        sans: ['var(--font-montserrat)', 'sans-serif'],
+        inter: ['var(--font-montserrat)', 'sans-serif'],
+        roboto: ['var(--font-montserrat)', 'sans-serif'],
+        robotoslab: ['var(--font-bitter)', 'serif'],
         robotomono: ['var(--font-roboto-mono)', 'sans-serif'],
-        crimson: ['var(--font-crimson-pro)', 'serif'],
+        crimson: ['var(--font-bitter)', 'serif'],
         montserrat: ['var(--font-montserrat)', 'sans-serif'],
-        bitter: ['var(--font-bitter)', 'sans-serif'],
-        fira: ['var(--font-fira-sans)', 'sans-serif'],
+        monserrat: ['var(--font-montserrat)', 'sans-serif'],
+        bitter: ['var(--font-bitter)', 'serif'],
+        fira: ['var(--font-montserrat)', 'sans-serif'],
       },
       colors: {
         background: 'var(--background)',
@@ -33,7 +34,7 @@ const config: Config = {
         lavanda2: 'rgba(199, 180, 245, 1)',
         second: colors.red, //green-600
         verde: 'rgba(17, 122, 101, 1)',
-        dorado: 'rgba(212, 175, 55, 1)'
+        dorado: 'rgba(212, 175, 55, 1)',
       },
       lineHeight: {
         'extra-tight': '1px',


### PR DESCRIPTION
## Qué cambia

- Renderiza los bloques de Sanity con SSR y elimina cargas dinámicas que dejaban el HTML inicial vacío.
- Añade caché y consultas GROQ más pequeñas, reduce fuentes e imágenes innecesarias y mejora la configuración de Next/Image.
- Incorpora campos SEO reutilizables en Sanity, metadata por documento, canonical, Open Graph, Twitter y JSON-LD seguro.
- Genera sitemap y robots coherentes, excluye contenido inactivo/noindex y devuelve 404 reales para documentos inexistentes.
- Corrige bloqueos de build por variables opcionales y actualiza Next.js 14 a 14.2.35.

## Impacto esperado

- Mejor LCP y menor JavaScript/fuentes transferidas.
- Contenido indexable disponible en el HTML de servidor.
- Mejor control editorial de títulos, descripciones, canonical, indexación e imágenes sociales.
- Menos lecturas y payload desde Sanity.

## Verificación

- `next build`
- `tsc --noEmit`
- `next lint` (solo advertencias Tailwind preexistentes)
- Pruebas HTTP de SSR, canonical, un solo H1, 404/noindex, sitemap y robots

## Nota del entorno

La comprobación visual automatizada no pudo iniciarse porque el contenedor no permite instalar mediante sudo las bibliotecas de Chrome. La salida HTML y las rutas se verificaron directamente contra el servidor de producción local.
